### PR TITLE
feat(flags): Builder Toml Config Support

### DIFF
--- a/builder/config.go
+++ b/builder/config.go
@@ -1,0 +1,36 @@
+package builder
+
+type Config struct {
+	Enabled               bool   `toml:",omitempty"`
+	EnableValidatorChecks bool   `toml:",omitempty"`
+	EnableLocalRelay      bool   `toml:",omitempty"`
+	DisableBundleFetcher  bool   `toml:",omitempty"`
+	DryRun                bool   `toml:",omitempty"`
+	BuilderSecretKey      string `toml:",omitempty"`
+	RelaySecretKey        string `toml:",omitempty"`
+	ListenAddr            string `toml:",omitempty"`
+	GenesisForkVersion    string `toml:",omitempty"`
+	BellatrixForkVersion  string `toml:",omitempty"`
+	GenesisValidatorsRoot string `toml:",omitempty"`
+	BeaconEndpoint        string `toml:",omitempty"`
+	RemoteRelayEndpoint   string `toml:",omitempty"`
+	ValidationBlocklist   string `toml:",omitempty"`
+}
+
+// DefaultConfig is the default config for the builder.
+var DefaultConfig = Config{
+	Enabled:               false,
+	EnableValidatorChecks: false,
+	EnableLocalRelay:      false,
+	DisableBundleFetcher:  false,
+	DryRun:                false,
+	BuilderSecretKey:      "0x2fc12ae741f29701f8e30f5de6350766c020cb80768a0ff01e6838ffd2431e11",
+	RelaySecretKey:        "0x2fc12ae741f29701f8e30f5de6350766c020cb80768a0ff01e6838ffd2431e11",
+	ListenAddr:            ":28545",
+	GenesisForkVersion:    "0x00000000",
+	BellatrixForkVersion:  "0x02000000",
+	GenesisValidatorsRoot: "0x0000000000000000000000000000000000000000000000000000000000000000",
+	BeaconEndpoint:        "http://127.0.0.1:5052",
+	RemoteRelayEndpoint:   "",
+	ValidationBlocklist:   "",
+}

--- a/builder/service.go
+++ b/builder/service.go
@@ -104,24 +104,7 @@ func NewService(listenAddr string, localRelay *LocalRelay, builder *Builder) *Se
 	}
 }
 
-type BuilderConfig struct {
-	Enabled               bool
-	EnableValidatorChecks bool
-	EnableLocalRelay      bool
-	DisableBundleFetcher  bool
-	DryRun                bool
-	BuilderSecretKey      string
-	RelaySecretKey        string
-	ListenAddr            string
-	GenesisForkVersion    string
-	BellatrixForkVersion  string
-	GenesisValidatorsRoot string
-	BeaconEndpoint        string
-	RemoteRelayEndpoint   string
-	ValidationBlocklist   string
-}
-
-func Register(stack *node.Node, backend *eth.Ethereum, cfg *BuilderConfig) error {
+func Register(stack *node.Node, backend *eth.Ethereum, cfg *Config) error {
 	envRelaySkBytes, err := hexutil.Decode(cfg.RelaySecretKey)
 	if err != nil {
 		return errors.New("incorrect builder API secret key provided")

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -1554,6 +1554,24 @@ func SetP2PConfig(ctx *cli.Context, cfg *p2p.Config) {
 	}
 }
 
+// SetBuilderConfig applies node-related command line flags to the config.
+func SetBuilderConfig(ctx *cli.Context, cfg *builder.Config) {
+	cfg.Enabled = ctx.IsSet(BuilderEnabled.Name)
+	cfg.EnableValidatorChecks = ctx.IsSet(BuilderEnableValidatorChecks.Name)
+	cfg.EnableLocalRelay = ctx.IsSet(BuilderEnableLocalRelay.Name)
+	cfg.DisableBundleFetcher = ctx.IsSet(BuilderDisableBundleFetcher.Name)
+	cfg.DryRun = ctx.IsSet(BuilderDryRun.Name)
+	cfg.BuilderSecretKey = ctx.String(BuilderSecretKey.Name)
+	cfg.RelaySecretKey = ctx.String(BuilderRelaySecretKey.Name)
+	cfg.ListenAddr = ctx.String(BuilderListenAddr.Name)
+	cfg.GenesisForkVersion = ctx.String(BuilderGenesisForkVersion.Name)
+	cfg.BellatrixForkVersion = ctx.String(BuilderBellatrixForkVersion.Name)
+	cfg.GenesisValidatorsRoot = ctx.String(BuilderGenesisValidatorsRoot.Name)
+	cfg.BeaconEndpoint = ctx.String(BuilderBeaconEndpoint.Name)
+	cfg.RemoteRelayEndpoint = ctx.String(BuilderRemoteRelayEndpoint.Name)
+	cfg.ValidationBlocklist = ctx.String(BuilderBlockValidationBlacklistSourceFilePath.Name)
+}
+
 // SetNodeConfig applies node-related command line flags to the config.
 func SetNodeConfig(ctx *cli.Context, cfg *node.Config) {
 	SetP2PConfig(ctx, &cfg.P2P)
@@ -2112,7 +2130,7 @@ func SetDNSDiscoveryDefaults(cfg *ethconfig.Config, genesis common.Hash) {
 // RegisterEthService adds an Ethereum client to the stack.
 // The second return value is the full node instance, which may be nil if the
 // node is running as a light client.
-func RegisterEthService(stack *node.Node, cfg *ethconfig.Config, bpCfg *builder.BuilderConfig) (ethapi.Backend, *eth.Ethereum) {
+func RegisterEthService(stack *node.Node, cfg *ethconfig.Config, bpCfg *builder.Config) (ethapi.Backend, *eth.Ethereum) {
 	if cfg.SyncMode == downloader.LightSync {
 		backend, err := les.New(stack, cfg)
 		if err != nil {


### PR DESCRIPTION
## Overview

Allows builder flags to be set via the toml config in addition to cli flags.

---

* [x] I have seen and agree to [`CONTRIBUTING.md`](https://github.com/flashbots/builder/blob/main/CONTRIBUTING.md)
