### PR TITLE
Use snapshots for blocklist revert

### DIFF
--- a/core/chain_makers.go
+++ b/core/chain_makers.go
@@ -103,7 +103,7 @@ func (b *BlockGen) AddTxWithChain(bc *BlockChain, tx *types.Transaction) {
 		b.SetCoinbase(common.Address{})
 	}
 	b.statedb.Prepare(tx.Hash(), len(b.txs))
-	receipt, err := ApplyTransaction(b.config, bc, &b.header.Coinbase, b.gasPool, b.statedb, b.header, tx, &b.header.GasUsed, vm.Config{})
+	receipt, err := ApplyTransaction(b.config, bc, &b.header.Coinbase, b.gasPool, b.statedb, b.header, tx, &b.header.GasUsed, vm.Config{}, nil)
 	if err != nil {
 		panic(err)
 	}

--- a/core/state_processor.go
+++ b/core/state_processor.go
@@ -79,7 +79,7 @@ func (p *StateProcessor) Process(block *types.Block, statedb *state.StateDB, cfg
 			return nil, nil, 0, fmt.Errorf("could not apply tx %d [%v]: %w", i, tx.Hash().Hex(), err)
 		}
 		statedb.Prepare(tx.Hash(), i)
-		receipt, err := applyTransaction(msg, p.config, nil, gp, statedb, blockNumber, blockHash, tx, usedGas, vmenv)
+		receipt, err := applyTransaction(msg, p.config, nil, gp, statedb, blockNumber, blockHash, tx, usedGas, vmenv, nil)
 		if err != nil {
 			return nil, nil, 0, fmt.Errorf("could not apply tx %d [%v]: %w", i, tx.Hash().Hex(), err)
 		}
@@ -92,15 +92,23 @@ func (p *StateProcessor) Process(block *types.Block, statedb *state.StateDB, cfg
 	return receipts, allLogs, *usedGas, nil
 }
 
-func applyTransaction(msg types.Message, config *params.ChainConfig, author *common.Address, gp *GasPool, statedb *state.StateDB, blockNumber *big.Int, blockHash common.Hash, tx *types.Transaction, usedGas *uint64, evm *vm.EVM) (*types.Receipt, error) {
+func applyTransaction(msg types.Message, config *params.ChainConfig, author *common.Address, gp *GasPool, statedb *state.StateDB, blockNumber *big.Int, blockHash common.Hash, tx *types.Transaction, usedGas *uint64, evm *vm.EVM, preFinalizeHook func() error) (*types.Receipt, error) {
 	// Create a new context to be used in the EVM environment.
 	txContext := NewEVMTxContext(msg)
 	evm.Reset(txContext, statedb)
 
+	snapshot := statedb.Snapshot()
 	// Apply the transaction to the current state (included in the env).
 	result, err := ApplyMessage(evm, msg, gp)
 	if err != nil {
 		return nil, err
+	}
+	if preFinalizeHook != nil {
+		err = preFinalizeHook()
+		if err != nil {
+			statedb.RevertToSnapshot(snapshot)
+			return nil, err
+		}
 	}
 
 	// Update the state with pending changes.
@@ -186,7 +194,7 @@ func applyTransactionWithResult(msg types.Message, config *params.ChainConfig, b
 // and uses the input parameters for its environment. It returns the receipt
 // for the transaction, gas used and an error if the transaction failed,
 // indicating the block was invalid.
-func ApplyTransaction(config *params.ChainConfig, bc ChainContext, author *common.Address, gp *GasPool, statedb *state.StateDB, header *types.Header, tx *types.Transaction, usedGas *uint64, cfg vm.Config) (*types.Receipt, error) {
+func ApplyTransaction(config *params.ChainConfig, bc ChainContext, author *common.Address, gp *GasPool, statedb *state.StateDB, header *types.Header, tx *types.Transaction, usedGas *uint64, cfg vm.Config, preFinalizeHook func() error) (*types.Receipt, error) {
 	msg, err := tx.AsMessage(types.MakeSigner(config, header.Number), header.BaseFee)
 	if err != nil {
 		return nil, err
@@ -194,7 +202,7 @@ func ApplyTransaction(config *params.ChainConfig, bc ChainContext, author *commo
 	// Create a new context to be used in the EVM environment
 	blockContext := NewEVMBlockContext(header, bc, author)
 	vmenv := vm.NewEVM(blockContext, vm.TxContext{}, statedb, config, cfg)
-	return applyTransaction(msg, config, author, gp, statedb, header.Number, header.Hash(), tx, usedGas, vmenv)
+	return applyTransaction(msg, config, author, gp, statedb, header.Number, header.Hash(), tx, usedGas, vmenv, preFinalizeHook)
 }
 
 func ApplyTransactionWithResult(config *params.ChainConfig, bc ChainContext, author *common.Address, gp *GasPool, statedb *state.StateDB, header *types.Header, tx *types.Transaction, usedGas *uint64, cfg vm.Config) (*types.Receipt, *ExecutionResult, error) {

--- a/miner/algo_common_test.go
+++ b/miner/algo_common_test.go
@@ -71,7 +71,7 @@ func simulateBundle(env *environment, bundle types.MevBundle, chData chainData, 
 		coinbaseBalanceBefore := stateDB.GetBalance(env.coinbase)
 
 		var tempGasUsed uint64
-		receipt, err := core.ApplyTransaction(chData.chainConfig, chData.chain, &env.coinbase, gasPool, stateDB, env.header, tx, &tempGasUsed, *chData.chain.GetVMConfig())
+		receipt, err := core.ApplyTransaction(chData.chainConfig, chData.chain, &env.coinbase, gasPool, stateDB, env.header, tx, &tempGasUsed, *chData.chain.GetVMConfig(), nil)
 		if err != nil {
 			return types.SimulatedBundle{}, err
 		}
@@ -439,6 +439,8 @@ func TestBlacklist(t *testing.T) {
 	env := newEnvironment(chData, statedb, signers.addresses[0], GasLimit, big.NewInt(1))
 	envDiff := newEnvironmentDiff(env)
 
+	beforeRoot := statedb.IntermediateRoot(true)
+
 	blacklist := map[common.Address]struct{}{
 		signers.addresses[3]: {},
 	}
@@ -493,6 +495,11 @@ func TestBlacklist(t *testing.T) {
 
 	if len(envDiff.newReceipts) != 0 {
 		t.Fatal("newReceipts changed")
+	}
+
+	afterRoot := statedb.IntermediateRoot(true)
+	if beforeRoot != afterRoot {
+		t.Fatal("statedb root changed")
 	}
 }
 

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -919,12 +919,7 @@ func (w *worker) updateSnapshot(env *environment) {
 func (w *worker) commitTransaction(env *environment, tx *types.Transaction) ([]*types.Log, error) {
 	gasPool := *env.gasPool
 	envGasUsed := env.header.GasUsed
-	var stateDB *state.StateDB
-	if len(w.blockList) != 0 {
-		stateDB = env.state.Copy()
-	} else {
-		stateDB = env.state
-	}
+	stateDB := env.state
 
 	// It's important to copy then .Prepare() - don't reorder.
 	stateDB.Prepare(tx.Hash(), env.tcount)
@@ -937,24 +932,26 @@ func (w *worker) commitTransaction(env *environment, tx *types.Transaction) ([]*
 	}
 
 	var tracer *logger.AccountTouchTracer
+	var hook func() error
 	config := *w.chain.GetVMConfig()
 	if len(w.blockList) != 0 {
 		tracer = logger.NewAccountTouchTracer()
 		config.Tracer = tracer
 		config.Debug = true
+		hook = func() error {
+			for _, address := range tracer.TouchedAddresses() {
+				if _, in := w.blockList[address]; in {
+					return errBlocklistViolation
+				}
+			}
+			return nil
+		}
 	}
 
-	receipt, err := core.ApplyTransaction(w.chainConfig, w.chain, &env.coinbase, &gasPool, stateDB, env.header, tx, &envGasUsed, config)
+	receipt, err := core.ApplyTransaction(w.chainConfig, w.chain, &env.coinbase, &gasPool, stateDB, env.header, tx, &envGasUsed, config, hook)
 	if err != nil {
 		stateDB.RevertToSnapshot(snapshot)
 		return nil, err
-	}
-	if len(w.blockList) != 0 {
-		for _, address := range tracer.TouchedAddresses() {
-			if _, in := w.blockList[address]; in {
-				return nil, errBlocklistViolation
-			}
-		}
 	}
 
 	*env.gasPool = gasPool
@@ -1769,7 +1766,7 @@ func (w *worker) computeBundleGas(env *environment, bundle types.MevBundle, stat
 			config.Tracer = tracer
 			config.Debug = true
 		}
-		receipt, err := core.ApplyTransaction(w.chainConfig, w.chain, &env.coinbase, gasPool, state, env.header, tx, &tempGasUsed, config)
+		receipt, err := core.ApplyTransaction(w.chainConfig, w.chain, &env.coinbase, gasPool, state, env.header, tx, &tempGasUsed, config, nil)
 		if err != nil {
 			return simulatedBundle{}, err
 		}


### PR DESCRIPTION
Removes state copying when applying individual tx that can potentially be reverted. 