### PR TITLE
Pre-grow string builder

### DIFF
--- a/core/asm/compiler.go
+++ b/core/asm/compiler.go
@@ -106,6 +106,7 @@ func (c *Compiler) Compile() (string, []error) {
 
 	// turn the binary to hex
 	var bin strings.Builder
+	bin.Grow(len(c.binary))
 	for _, v := range c.binary {
 		switch v := v.(type) {
 		case vm.OpCode:


### PR DESCRIPTION
## 📝 Summary

Grow builder before using it to avoid unnecessary memory allocation and copy.

## 📚 References

`strings.Builder` is backed by a slice, so `Grow()` pre-allocates this slice
https://cs.opensource.google/go/go/+/refs/tags/go1.19.3:src/strings/builder.go;l=15

---

* [x] I have seen and agree to [`CONTRIBUTING.md`](https://github.com/flashbots/builder/blob/main/CONTRIBUTING.md)
