### PR TITLE
Fix empty secondary relays bug

### DIFF
--- a/builder/config.go
+++ b/builder/config.go
@@ -33,6 +33,6 @@ var DefaultConfig = Config{
 	GenesisValidatorsRoot:         "0x0000000000000000000000000000000000000000000000000000000000000000",
 	BeaconEndpoint:                "http://127.0.0.1:5052",
 	RemoteRelayEndpoint:           "",
-	SecondaryRemoteRelayEndpoints: nil,
+	SecondaryRemoteRelayEndpoints: []string{},
 	ValidationBlocklist:           "",
 }

--- a/builder/service.go
+++ b/builder/service.go
@@ -160,7 +160,7 @@ func Register(stack *node.Node, backend *eth.Ethereum, cfg *Config) error {
 		return errors.New("neither local nor remote relay specified")
 	}
 
-	if len(cfg.SecondaryRemoteRelayEndpoints) > 0 {
+	if len(cfg.SecondaryRemoteRelayEndpoints) > 0 && cfg.SecondaryRemoteRelayEndpoints[0] != "" {
 		secondaryRelays := make([]IRelay, len(cfg.SecondaryRemoteRelayEndpoints))
 		for i, endpoint := range cfg.SecondaryRemoteRelayEndpoints {
 			secondaryRelays[i] = NewRemoteRelay(endpoint, nil)


### PR DESCRIPTION
For empty strings, `strings.Split()` always returns an array with length 1 - one empty string. This was adding in a remote relay with an empty endpoint:
```
+ log.Info("Getting validators", endpoint, r.endpoint+"/relay/v1/builder/validators")

INFO [12-05|16:48:45.362] Getting validators                       endpoint=/relay/v1/builder/validators
...
ERROR[12-05|16:48:45.362] could not get validators map from relay, retrying err="Get \"/relay/v1/builder/validators\": unsupported protocol scheme \"\""
ERROR[12-05|16:48:48.364] could not get validators map from relay  err="Get \"/relay/v1/builder/validators\": unsupported protocol scheme \"\""
ERROR[12-05|16:48:48.364] could not connect to remote relay, continuing anyway err="Get \"/relay/v1/builder/validators\": unsupported protocol scheme \"\""
```

cc @Ruteri 

---

* [x] I have seen and agree to [`CONTRIBUTING.md`](https://github.com/flashbots/builder/blob/main/CONTRIBUTING.md)
