### PR TITLE
Block Building Algorithm Tests

### DIFF
--- a/miner/algo_common_test.go
+++ b/miner/algo_common_test.go
@@ -186,14 +186,19 @@ func genGenesisAlloc(sign signerList, contractAddr []common.Address, contractCod
 
 func genTestSetup() (*state.StateDB, chainData, signerList) {
 	config := params.AllEthashProtocolChanges
-	db := rawdb.NewMemoryDatabase()
-	signerList := genSignerList(10, config)
-
+	signerList := genSignerList(10, params.AllEthashProtocolChanges)
 	genesisAlloc := genGenesisAlloc(signerList, []common.Address{payProxyAddress, logContractAddress}, [][]byte{payProxyCode, logContractCode})
+
+	stateDB, chainData := genTestSetupWithAlloc(config, genesisAlloc)
+	return stateDB, chainData, signerList
+}
+
+func genTestSetupWithAlloc(config *params.ChainConfig, alloc core.GenesisAlloc) (*state.StateDB, chainData) {
+	db := rawdb.NewMemoryDatabase()
 
 	gspec := &core.Genesis{
 		Config: config,
-		Alloc:  genesisAlloc,
+		Alloc:  alloc,
 	}
 	_ = gspec.MustCommit(db)
 
@@ -201,7 +206,7 @@ func genTestSetup() (*state.StateDB, chainData, signerList) {
 
 	stateDB, _ := state.New(chain.CurrentHeader().Root, state.NewDatabase(db), nil)
 
-	return stateDB, chainData{config, chain, nil}, signerList
+	return stateDB, chainData{config, chain, nil}
 }
 
 func newEnvironment(data chainData, state *state.StateDB, coinbase common.Address, gasLimit uint64, baseFee *big.Int) *environment {

--- a/miner/algo_contracts_test.go
+++ b/miner/algo_contracts_test.go
@@ -1,0 +1,27 @@
+package miner
+
+import (
+	"encoding/hex"
+)
+
+// Contracts used for testing.
+var (
+	// Always revert and consume all gas.
+	//
+	// pc    op       bytecode
+	// 0x00  INVALID  0xfe
+	contractRevert = parseCode("0xfe")
+)
+
+// parseCode converts a hex bytecode to a byte slice, or panics if the hex
+// bytecode is invalid.
+func parseCode(hexStr string) []byte {
+	if hexStr[0] == '0' && (hexStr[1] == 'x' || hexStr[1] == 'X') {
+		hexStr = hexStr[2:]
+	}
+	data, err := hex.DecodeString(hexStr)
+	if err != nil {
+		panic(err)
+	}
+	return data
+}

--- a/miner/algo_contracts_test.go
+++ b/miner/algo_contracts_test.go
@@ -11,6 +11,26 @@ var (
 	// pc    op       bytecode
 	// 0x00  INVALID  0xfe
 	contractRevert = parseCode("0xfe")
+
+	// Send the entire balance of the contract to the caller or revert and
+	// consume all gas, if the contracts balance is zero.
+	//
+	// pc    op           stack                  bytecode
+	// 0x00  SELFBALANCE  bal                    0x47
+	// 0x01  PUSH1 0x05   0x05 bal               0x6005
+	// 0x03  JUMPI        .                      0x57
+	// 0x04  INVALID      .                      0xfe
+	// 0x05  JUMPDEST     .                      0x5b
+	//
+	// 0x06  MSIZE        0                      0x59
+	// 0x07  MSIZE        0 0                    0x59
+	// 0x08  MSIZE        0 0 0                  0x59
+	// 0x09  MSIZE        0 0 0 0                0x59
+	// 0x0a  SELFBALANCE  bal 0 0 0 0 0          0x47
+	// 0x0b  CALLER       clr bal 0 0 0 0 0      0x33
+	// 0x0c  GAS          gas clr bal 0 0 0 0 0  0x5a
+	// 0x0d  CALL         .                      0xf1
+	contractSendBalance = parseCode("0x47600557fe5b5959595947335af100")
 )
 
 // parseCode converts a hex bytecode to a byte slice, or panics if the hex

--- a/miner/algo_test.go
+++ b/miner/algo_test.go
@@ -101,6 +101,31 @@ var algoTests = []*algoTest{
 		},
 		WantProfit: big.NewInt(50_000),
 	},
+	{
+		// Single failing tx that is included in the tx pool and in a bundle that is not allowed to
+		// revert.
+		//
+		// Tx should be included.
+		Name:   "simple-contradiction",
+		Header: &types.Header{GasLimit: 50_000},
+		Alloc: []core.GenesisAccount{
+			{Balance: big.NewInt(50_000)},
+			{Code: contractRevert},
+		},
+		TxPool: func(acc accByIndex) map[int][]types.TxData {
+			return map[int][]types.TxData{
+				0: {
+					&types.LegacyTx{Nonce: 0, Gas: 50_000, To: acc(1), GasPrice: big.NewInt(1)},
+				},
+			}
+		},
+		Bundles: func(acc accByIndex, sign signByIndex, txs txByAccIndexAndNonce) []*bundle {
+			return []*bundle{
+				{Txs: types.Transactions{txs(0, 0)}},
+			}
+		},
+		WantProfit: big.NewInt(50_000),
+	},
 }
 
 func TestAlgo(t *testing.T) {

--- a/miner/algo_test.go
+++ b/miner/algo_test.go
@@ -1,0 +1,238 @@
+package miner
+
+import (
+	"crypto/ecdsa"
+	"crypto/rand"
+	"fmt"
+	"math/big"
+	"sync"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/ethereum/go-ethereum/params"
+)
+
+var algoTests = []*algoTest{
+	{
+		Name: "simple",
+		Header: &types.Header{
+			GasLimit: 21_000,
+		},
+		Alloc: []core.GenesisAccount{
+			{Balance: big.NewInt(21_000)},
+			{Balance: big.NewInt(2 * 21_000)},
+		},
+		TxPool: func(acc accByIndex) map[int][]types.TxData {
+			return map[int][]types.TxData{
+				0: {
+					&types.LegacyTx{Nonce: 0, To: acc(0), Gas: 21_000, GasPrice: big.NewInt(1)},
+				},
+				1: {
+					&types.LegacyTx{Nonce: 0, To: acc(1), Gas: 21_000, GasPrice: big.NewInt(2)},
+				},
+			}
+		},
+		WantProfit: big.NewInt(2 * 21_000),
+	},
+	{
+		Name: "lookahead",
+		Header: &types.Header{
+			GasLimit: 42_000,
+		},
+		Alloc: []core.GenesisAccount{
+			{Balance: big.NewInt(21_000)},
+			{Balance: big.NewInt(3 * 21_000)},
+		},
+		TxPool: func(acc accByIndex) map[int][]types.TxData {
+			return map[int][]types.TxData{
+				0: {
+					&types.LegacyTx{Nonce: 0, Gas: 21_000, To: acc(0), GasPrice: big.NewInt(1)},
+				},
+				1: {
+					&types.LegacyTx{Nonce: 0, Gas: 21_000, To: acc(1), GasPrice: big.NewInt(1)},
+					&types.LegacyTx{Nonce: 1, Gas: 21_000, To: acc(1), GasPrice: big.NewInt(2)},
+				},
+			}
+		},
+		WantProfit: big.NewInt(3 * 21_000),
+	},
+}
+
+func TestAlgo(t *testing.T) {
+	var (
+		config = params.AllEthashProtocolChanges
+		signer = types.LatestSigner(config)
+	)
+
+	for _, test := range algoTests {
+		t.Run(test.Name, func(t *testing.T) {
+			alloc, txPool, err := test.build(signer, 1)
+			if err != nil {
+				t.Fatalf("Build: %v", err)
+			}
+
+			gotProfit, err := runAlgoTest(config, alloc, txPool, test.Header, 1)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if test.WantProfit.Cmp(gotProfit) != 0 {
+				t.Fatalf("Profit: want %v, got %v", test.WantProfit, gotProfit)
+			}
+		})
+	}
+}
+
+func BenchmarkAlgo(b *testing.B) {
+	var (
+		config = params.AllEthashProtocolChanges
+		signer = types.LatestSigner(config)
+		scales = []int{1, 10, 100}
+	)
+
+	for _, test := range algoTests {
+		for _, scale := range scales {
+			wantScaledProfit := new(big.Int).Mul(
+				big.NewInt(int64(scale)),
+				test.WantProfit,
+			)
+
+			b.Run(fmt.Sprintf("%s_%d", test.Name, scale), func(b *testing.B) {
+				alloc, txPool, err := test.build(signer, scale)
+				if err != nil {
+					b.Fatalf("Build: %v", err)
+				}
+
+				b.ResetTimer()
+				var txPoolCopy map[common.Address]types.Transactions
+				for i := 0; i < b.N; i++ {
+					// Note: copy is needed as the greedyAlgo modifies the txPool.
+					func() {
+						b.StopTimer()
+						defer b.StartTimer()
+
+						txPoolCopy = make(map[common.Address]types.Transactions, len(txPool))
+						for addr, txs := range txPool {
+							txPoolCopy[addr] = txs
+						}
+					}()
+
+					gotProfit, err := runAlgoTest(config, alloc, txPoolCopy, test.Header, scale)
+					if err != nil {
+						b.Fatal(err)
+					}
+					if wantScaledProfit.Cmp(gotProfit) != 0 {
+						b.Fatalf("Profit: want %v, got %v", wantScaledProfit, gotProfit)
+					}
+				}
+			})
+		}
+	}
+}
+
+// runAlgo executes a single algoTest case and returns the profit.
+func runAlgoTest(config *params.ChainConfig, alloc core.GenesisAlloc, txPool map[common.Address]types.Transactions, header *types.Header, scale int) (gotProfit *big.Int, err error) {
+	var (
+		statedb, chData = genTestSetupWithAlloc(config, alloc)
+		env             = newEnvironment(chData, statedb, header.Coinbase, header.GasLimit*uint64(scale), header.BaseFee)
+		builder         = newGreedyBuilder(chData.chain, chData.chainConfig, nil, env, nil, nil)
+
+		bundles = make([]types.SimulatedBundle, 0)
+	)
+
+	// build block
+	resultEnv, _ := builder.buildBlock(bundles, txPool)
+	return resultEnv.profit, nil
+}
+
+// algoTest represents a block builder algorithm test case.
+type algoTest struct {
+	once sync.Once
+
+	Name   string
+	Header *types.Header
+	Alloc  []core.GenesisAccount
+	TxPool func(accByIndex) map[int][]types.TxData
+
+	WantProfit *big.Int
+}
+
+func (test *algoTest) setDefaults() {
+	// set header defaults
+	if test.Header.Coinbase == (common.Address{}) {
+		test.Header.Coinbase = randAddr()
+	}
+	if test.Header.Number == nil {
+		test.Header.Number = big.NewInt(0)
+	}
+	if test.Header.BaseFee == nil {
+		test.Header.BaseFee = big.NewInt(0)
+	}
+}
+
+func (test *algoTest) build(signer types.Signer, scale int) (alloc core.GenesisAlloc, txPool map[common.Address]types.Transactions, err error) {
+	test.once.Do(test.setDefaults)
+
+	// generate accounts
+	n := len(test.Alloc) // number of accounts
+	addrs, prvs := genRandAccs(n * scale)
+
+	// build alloc
+	alloc = make(core.GenesisAlloc, n*scale)
+	txPool = make(map[common.Address]types.Transactions)
+
+	for s := 0; s < scale; s++ {
+		for i, acc := range test.Alloc {
+			alloc[addrs[s*n+i]] = acc
+		}
+
+		// define account by index function
+		accByIndexFn := func(i int) *common.Address {
+			if i < 0 || i >= n {
+				panic(fmt.Sprintf("invalid account %d, should be in [0, %d]", i, n-1))
+			}
+			return &addrs[s*n+i]
+		}
+
+		// build tx pool
+		preTxPool := test.TxPool(accByIndexFn)
+		for i, txs := range preTxPool {
+			if i < 0 || i >= n {
+				panic(fmt.Sprintf("invalid account %d, should be in [0, %d]", i, n-1))
+			}
+
+			signedTxs := make(types.Transactions, len(txs))
+			for j, tx := range txs {
+				signedTxs[j] = types.MustSignNewTx(prvs[s*n+i], signer, tx)
+			}
+			txPool[addrs[s*n+i]] = signedTxs
+		}
+	}
+	return
+}
+
+// randAddr returns a random address.
+func randAddr() (addr common.Address) {
+	rand.Read(addr[:])
+	return addr
+}
+
+// genRandAccs generates n random accounts.
+func genRandAccs(n int) ([]common.Address, []*ecdsa.PrivateKey) {
+	addrs := make([]common.Address, n)
+	prvs := make([]*ecdsa.PrivateKey, n)
+
+	for i := 0; i < n; i++ {
+		prv, err := crypto.GenerateKey()
+		if err != nil {
+			panic(fmt.Sprintf("genRandAccs: %v", err))
+		}
+		prvs[i] = prv
+		addrs[i] = crypto.PubkeyToAddress(prv.PublicKey)
+	}
+	return addrs, prvs
+}
+
+type accByIndex func(int) *common.Address


### PR DESCRIPTION
## 📝 Summary

This PR adds a test suite and benchmarks for the `miner.greedyBuilder` that consists of very small tx pools and bundles and their maximum validator profit. Small tx pools and bundle sets are easy to reason about and good for testing exactly one aspect of the block builder. It is also straight forward to add new test cases to the suite.

The test cases can be inflated/scaled up to produce bigger transaction pools and bundle sets which is useful for benchmarks. In the future this framework could be extended to generate tx pools and bundle sets consisting of a combination of test cases to produce more realistic input for the builder.

<!-- 
## 📚 References

Any interesting external links to documentation, articles, tweets which add value to the PR
-->

---

* [X] I have seen and agree to [`CONTRIBUTING.md`](https://github.com/flashbots/builder/blob/main/CONTRIBUTING.md)
