### PR TITLE
Use tx sig cache in algo_common.go

### DIFF
--- a/miner/algo_common.go
+++ b/miner/algo_common.go
@@ -95,7 +95,7 @@ func applyTransactionWithBlacklist(signer types.Signer, config *params.ChainConf
 		return receipt, statedb, err
 	}
 
-	sender, err := signer.Sender(tx)
+	sender, err := types.Sender(signer, tx)
 	if err != nil {
 		return nil, statedb, err
 	}
@@ -376,7 +376,7 @@ func (envDiff *environmentDiff) commitPayoutTx(amount *big.Int, sender, receiver
 		return nil, err
 	}
 
-	txSender, err := signer.Sender(tx)
+	txSender, err := types.Sender(signer, tx)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## 📝 Summary

Using `types.Sender(signer, tx)` instead of `signer.Sender(tx)` is much better because the former caches the result while the latter does not. It takes a significant amount of time to do it all the time. (around 10% of the block building time is wasted because of the changed line in `applyTransactionWithBlacklist`).

The line in `commitPayoutTx` does not matter because we see that tx only once but its still nice to have one way to do it in the code.