### PR TITLE
Bundle cancellations

### DIFF
--- a/builder/builder_test.go
+++ b/builder/builder_test.go
@@ -126,13 +126,20 @@ func TestOnPayloadAttributes(t *testing.T) {
 
 	require.Equal(t, uint64(25), testRelay.requestedSlot)
 
-	// Clear the submitted message and check that the job will be ran again and but a new message will not be submitted since the profit is the same
+	// Clear the submitted message and check that the job will be ran again and but a new message will not be submitted since the hash is the same
+	testBlock.Profit = big.NewInt(10)
 	testRelay.submittedMsg = nil
 	time.Sleep(2200 * time.Millisecond)
 	require.Nil(t, testRelay.submittedMsg)
 
-	// Up the profit, expect to get the block
-	testEthService.testBlock.Profit.SetInt64(11)
+	// Change the hash, expect to get the block
+	testExecutableData.ExtraData = hexutil.MustDecode("0x0042fafd")
+	testExecutableData.BlockHash = common.HexToHash("0x0579b1aaca5c079c91e5774bac72c7f9bc2ddf2b126e9c632be68a1cb8f3fc71")
+	testBlock, err = beacon.ExecutableDataToBlock(*testExecutableData)
+	testBlock.Profit = big.NewInt(10)
+	require.NoError(t, err)
+	testEthService.testBlock = testBlock
+
 	time.Sleep(2200 * time.Millisecond)
 	require.NotNil(t, testRelay.submittedMsg)
 }

--- a/builder/service.go
+++ b/builder/service.go
@@ -185,6 +185,7 @@ func Register(stack *node.Node, backend *eth.Ethereum, cfg *Config) error {
 		mevBundleCh := make(chan []types.MevBundle)
 		blockNumCh := make(chan int64)
 		bundleFetcher := flashbotsextra.NewBundleFetcher(backend, ds, blockNumCh, mevBundleCh, true)
+		backend.RegisterBundleFetcher(bundleFetcher)
 		go bundleFetcher.Run()
 	}
 

--- a/core/tx_pool.go
+++ b/core/tx_pool.go
@@ -17,6 +17,7 @@
 package core
 
 import (
+	"context"
 	"errors"
 	"math"
 	"math/big"
@@ -34,6 +35,7 @@ import (
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/metrics"
 	"github.com/ethereum/go-ethereum/params"
+	"github.com/google/uuid"
 	"golang.org/x/crypto/sha3"
 )
 
@@ -280,6 +282,8 @@ type TxPool struct {
 	initDoneCh      chan struct{}  // is closed once the pool is initialized (for tests)
 
 	changesSinceReorg int // A counter for how many drops we've performed in-between reorg.
+
+	bundleFetcher IFetcher
 }
 
 type txpoolResetRequest struct {
@@ -342,6 +346,17 @@ func NewTxPool(config TxPoolConfig, chainconfig *params.ChainConfig, chain block
 	go pool.loop()
 
 	return pool
+}
+
+type IFetcher interface {
+	GetLatestUuidBundles(ctx context.Context, blockNum int64) ([]types.LatestUuidBundle, error)
+}
+
+func (pool *TxPool) RegisterBundleFetcher(fetcher IFetcher) {
+	pool.mu.Lock()
+	defer pool.mu.Unlock()
+
+	pool.bundleFetcher = fetcher
 }
 
 // loop is the transaction pool's main event loop, waiting for and reacting to
@@ -581,21 +596,40 @@ func (pool *TxPool) Pending(enforceTips bool) map[common.Address]types.Transacti
 	return pending
 }
 
-/// AllMevBundles returns all the MEV Bundles currently in the pool
-func (pool *TxPool) AllMevBundles() []types.MevBundle {
-	return pool.mevBundles
-}
-
 // MevBundles returns a list of bundles valid for the given blockNumber/blockTimestamp
 // also prunes bundles that are outdated
-func (pool *TxPool) MevBundles(blockNumber *big.Int, blockTimestamp uint64) []types.MevBundle {
+// Returns regular bundles and a function resolving to current cancellable bundles
+func (pool *TxPool) MevBundles(blockNumber *big.Int, blockTimestamp uint64) ([]types.MevBundle, chan []types.MevBundle) {
 	pool.mu.Lock()
 	defer pool.mu.Unlock()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 500*time.Millisecond)
+
+	currentCancellableBundlesCh := make(chan []types.MevBundle, 1)
+	var errCh chan error
+	var lubCh chan []types.LatestUuidBundle
+	if pool.bundleFetcher == nil {
+		currentCancellableBundlesCh <- nil
+	} else {
+		errCh = make(chan error, 1)
+		lubCh = make(chan []types.LatestUuidBundle, 1)
+		go func(blockNum int64) {
+			lub, err := pool.bundleFetcher.GetLatestUuidBundles(ctx, blockNum)
+			errCh <- err
+			lubCh <- lub
+		}(blockNumber.Int64())
+	}
 
 	// returned values
 	var ret []types.MevBundle
 	// rolled over values
 	var bundles []types.MevBundle
+	type uuidBundleKey struct {
+		Uuid           uuid.UUID
+		SigningAddress common.Address
+	}
+	// (uuid, signingAddress) -> list of bundles
+	var uuidBundles = make(map[uuidBundleKey][]types.MevBundle)
 
 	for _, bundle := range pool.mevBundles {
 		// Prune outdated bundles
@@ -609,14 +643,77 @@ func (pool *TxPool) MevBundles(blockNumber *big.Int, blockTimestamp uint64) []ty
 			continue
 		}
 
-		// return the ones which are in time
-		ret = append(ret, bundle)
 		// keep the bundles around internally until they need to be pruned
 		bundles = append(bundles, bundle)
+
+		// TODO: omit duplicates
+
+		// do not append to the return quite yet, check the DB for the latest bundle for that uuid
+		if bundle.Uuid != types.EmptyUUID {
+			ubk := uuidBundleKey{bundle.Uuid, bundle.SigningAddress}
+			uuidBundles[ubk] = append(uuidBundles[ubk], bundle)
+			continue
+		}
+
+		// return the ones which are in time
+		ret = append(ret, bundle)
 	}
 
 	pool.mevBundles = bundles
-	return ret
+
+	if pool.bundleFetcher == nil {
+		cancel()
+		return ret, currentCancellableBundlesCh
+	}
+
+	if len(uuidBundles) == 0 {
+		cancel()
+		currentCancellableBundlesCh <- nil
+		return ret, currentCancellableBundlesCh
+	}
+
+	go func(map[uuidBundleKey][]types.MevBundle) {
+		defer cancel()
+		err := <-errCh
+		if err != nil {
+			log.Error("could not fetch latest bundles uuid map", "err", err)
+			currentCancellableBundlesCh <- nil
+			return
+		}
+		currentCancellableBundles := []types.MevBundle{}
+
+		log.Trace("Processing uuid bundles", "uuidBundles", uuidBundles)
+
+		lubs := <-lubCh
+		for _, lub := range lubs {
+			ubk := uuidBundleKey{lub.Uuid, lub.SigningAddress}
+			bundles, found := uuidBundles[ubk]
+			if !found {
+				log.Trace("missing uuid bundle", "ubk", ubk)
+				continue
+			}
+			for _, bundle := range bundles {
+				if bundle.Hash == lub.BundleHash {
+					log.Trace("Adding uuid bundle", "bundle hash", bundle.Hash.String(), "lub", lub)
+					currentCancellableBundles = append(currentCancellableBundles, bundle)
+					break
+				}
+			}
+		}
+		currentCancellableBundlesCh <- currentCancellableBundles
+	}(uuidBundles)
+
+	// TODO: wat do with the rest of the uuidBundles? Wat do if the db did not return?
+	// For now assuming all are cancelled for safety
+	/*
+		for ubk, pmbIs := range uuidBundles {
+			for _, pmbI := range pmbIs {
+				bundles = append(bundles, pool.mevBundles[pmbI])
+			}
+			ret = append(ret, bundles[len(bundles)-1])
+		}
+	*/
+	return ret, currentCancellableBundlesCh
 }
 
 // AddMevBundles adds a mev bundles to the pool
@@ -629,7 +726,7 @@ func (pool *TxPool) AddMevBundles(mevBundles []types.MevBundle) error {
 }
 
 // AddMevBundle adds a mev bundle to the pool
-func (pool *TxPool) AddMevBundle(txs types.Transactions, blockNumber *big.Int, minTimestamp, maxTimestamp uint64, revertingTxHashes []common.Hash) error {
+func (pool *TxPool) AddMevBundle(txs types.Transactions, blockNumber *big.Int, replacementUuid uuid.UUID, signingAddress common.Address, minTimestamp, maxTimestamp uint64, revertingTxHashes []common.Hash) error {
 	bundleHasher := sha3.NewLegacyKeccak256()
 	for _, tx := range txs {
 		bundleHasher.Write(tx.Hash().Bytes())
@@ -642,6 +739,8 @@ func (pool *TxPool) AddMevBundle(txs types.Transactions, blockNumber *big.Int, m
 	pool.mevBundles = append(pool.mevBundles, types.MevBundle{
 		Txs:               txs,
 		BlockNumber:       blockNumber,
+		Uuid:              replacementUuid,
+		SigningAddress:    signingAddress,
 		MinTimestamp:      minTimestamp,
 		MaxTimestamp:      maxTimestamp,
 		RevertingTxHashes: revertingTxHashes,

--- a/core/tx_pool_test.go
+++ b/core/tx_pool_test.go
@@ -17,6 +17,7 @@
 package core
 
 import (
+	"context"
 	"crypto/ecdsa"
 	"errors"
 	"fmt"
@@ -34,7 +35,10 @@ import (
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/event"
 	"github.com/ethereum/go-ethereum/params"
+	"github.com/ethereum/go-ethereum/test_utils"
 	"github.com/ethereum/go-ethereum/trie"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
 )
 
 var (
@@ -2417,6 +2421,117 @@ func TestTransactionSlotCount(t *testing.T) {
 	if slots := numSlots(bigTx); slots != 11 {
 		t.Fatalf("big transactions slot count mismatch: have %d want %d", slots, 11)
 	}
+}
+
+// TODO: test bundle cancellations
+func TestBundleCancellations(t *testing.T) {
+	// Create the pool to test the status retrievals with
+	statedb, _ := state.New(common.Hash{}, state.NewDatabase(rawdb.NewMemoryDatabase()), nil)
+	blockchain := &testBlockChain{100, statedb, new(event.Feed)}
+
+	pool := NewTxPool(testTxPoolConfig, params.TestChainConfig, blockchain)
+	fetcher := &mockFetcher{make(map[int64]error), make(map[int64][]types.LatestUuidBundle)}
+	pool.RegisterBundleFetcher(fetcher)
+
+	fetcher.resps[1] = nil
+	bundles, ccBundles := pool.MevBundles(big.NewInt(1), 20)
+	require.Equal(t, []types.MevBundle(nil), bundles)
+	require.Equal(t, []types.MevBundle(nil), <-ccBundles)
+
+	bundle01_uuid1_signer1 := types.MevBundle{
+		BlockNumber:    big.NewInt(1),
+		Uuid:           uuid.New(),
+		SigningAddress: common.Address{0x01},
+		Hash:           common.Hash{0xf0},
+	}
+	bundle02_no_uuid_signer2 := types.MevBundle{
+		BlockNumber:    big.NewInt(1),
+		Uuid:           types.EmptyUUID,
+		SigningAddress: common.Address{0x02},
+		Hash:           common.Hash{0xf1},
+	}
+	bundle03_uuid1_signer1 := types.MevBundle{
+		BlockNumber:    big.NewInt(1),
+		Uuid:           bundle01_uuid1_signer1.Uuid,
+		SigningAddress: common.Address{0x01},
+		Hash:           common.Hash{0xf3},
+	}
+	bundle03_uuid1_signer2 := types.MevBundle{
+		BlockNumber:    big.NewInt(1),
+		Uuid:           bundle01_uuid1_signer1.Uuid,
+		SigningAddress: common.Address{0x02},
+		Hash:           common.Hash{0xf3},
+	}
+
+	err := pool.AddMevBundles([]types.MevBundle{
+		bundle01_uuid1_signer1, bundle02_no_uuid_signer2, bundle03_uuid1_signer1, bundle03_uuid1_signer2,
+	})
+	require.NoError(t, err)
+
+	// Ignores uuid bundle since fetcher does not return it, passes non-uuid bundle
+	bundles, ccBundles = pool.MevBundles(big.NewInt(1), 20)
+	require.Equal(t, []types.MevBundle{bundle02_no_uuid_signer2}, bundles)
+	cr := test_utils.RequireChan[[]types.MevBundle](ccBundles, time.Millisecond)
+	require.False(t, cr.Timeout)
+	require.Equal(t, []types.MevBundle{}, cr.Value)
+
+	fetcher.resps[1] = append(fetcher.resps[1], types.LatestUuidBundle{
+		Uuid:           bundle01_uuid1_signer1.Uuid,
+		SigningAddress: bundle01_uuid1_signer1.SigningAddress,
+		BundleHash:     bundle01_uuid1_signer1.Hash,
+	})
+
+	// Passes non-uuid bundle and only the bundle exactly matching the fetcher resp
+	bundles, ccBundles = pool.MevBundles(big.NewInt(1), 20)
+	require.Equal(t, []types.MevBundle{bundle02_no_uuid_signer2}, bundles)
+	cr = test_utils.RequireChan[[]types.MevBundle](ccBundles, time.Millisecond)
+	require.False(t, cr.Timeout)
+	require.Equal(t, []types.MevBundle{bundle01_uuid1_signer1}, cr.Value)
+
+	fetcher.resps[1] = []types.LatestUuidBundle{
+		types.LatestUuidBundle{
+			Uuid:           bundle03_uuid1_signer1.Uuid,
+			SigningAddress: bundle03_uuid1_signer1.SigningAddress,
+			BundleHash:     bundle03_uuid1_signer1.Hash,
+		},
+	}
+
+	// Passes non-uuid bundle and only the bundle exactly matching the fetcher resp
+	bundles, ccBundles = pool.MevBundles(big.NewInt(1), 20)
+	require.Equal(t, []types.MevBundle{bundle02_no_uuid_signer2}, bundles)
+	cr = test_utils.RequireChan[[]types.MevBundle](ccBundles, time.Millisecond)
+	require.False(t, cr.Timeout)
+	require.Equal(t, []types.MevBundle{bundle03_uuid1_signer1}, cr.Value)
+
+	fetcher.resps[1] = append(fetcher.resps[1], types.LatestUuidBundle{
+		Uuid:           bundle03_uuid1_signer2.Uuid,
+		SigningAddress: bundle03_uuid1_signer2.SigningAddress,
+		BundleHash:     bundle03_uuid1_signer2.Hash,
+	})
+
+	// Passes non-uuid bundle and both bundles exactly matching the fetcher resp for the same hash
+	bundles, ccBundles = pool.MevBundles(big.NewInt(1), 20)
+	require.Equal(t, []types.MevBundle{bundle02_no_uuid_signer2}, bundles)
+	cr = test_utils.RequireChan[[]types.MevBundle](ccBundles, time.Millisecond)
+	require.False(t, cr.Timeout)
+	require.Equal(t, []types.MevBundle{bundle03_uuid1_signer1, bundle03_uuid1_signer2}, cr.Value)
+}
+
+type mockFetcher struct {
+	errorResps map[int64]error
+	resps      map[int64][]types.LatestUuidBundle
+}
+
+func (f *mockFetcher) GetLatestUuidBundles(_ context.Context, blockNum int64) ([]types.LatestUuidBundle, error) {
+	if err, found := f.errorResps[blockNum]; found {
+		return nil, err
+	}
+
+	if resp, found := f.resps[blockNum]; found {
+		return resp, nil
+	}
+
+	return nil, errors.New("unexpected block number")
 }
 
 // Benchmarks the speed of validating the contents of the pending queue of the

--- a/core/types/transaction.go
+++ b/core/types/transaction.go
@@ -29,6 +29,7 @@ import (
 	"github.com/ethereum/go-ethereum/common/math"
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/rlp"
+	"github.com/google/uuid"
 )
 
 var (
@@ -719,9 +720,19 @@ func copyAddressPtr(a *common.Address) *common.Address {
 	return &cpy
 }
 
+var EmptyUUID uuid.UUID
+
+type LatestUuidBundle struct {
+	Uuid           uuid.UUID
+	SigningAddress common.Address
+	BundleHash     common.Hash
+}
+
 type MevBundle struct {
 	Txs               Transactions
 	BlockNumber       *big.Int
+	Uuid              uuid.UUID
+	SigningAddress    common.Address
 	MinTimestamp      uint64
 	MaxTimestamp      uint64
 	RevertingTxHashes []common.Hash

--- a/eth/api_backend.go
+++ b/eth/api_backend.go
@@ -38,6 +38,7 @@ import (
 	"github.com/ethereum/go-ethereum/miner"
 	"github.com/ethereum/go-ethereum/params"
 	"github.com/ethereum/go-ethereum/rpc"
+	"github.com/google/uuid"
 )
 
 // EthAPIBackend implements ethapi.Backend for full nodes
@@ -254,8 +255,8 @@ func (b *EthAPIBackend) SendTx(ctx context.Context, signedTx *types.Transaction,
 	}
 }
 
-func (b *EthAPIBackend) SendBundle(ctx context.Context, txs types.Transactions, blockNumber rpc.BlockNumber, minTimestamp uint64, maxTimestamp uint64, revertingTxHashes []common.Hash) error {
-	return b.eth.txPool.AddMevBundle(txs, big.NewInt(blockNumber.Int64()), minTimestamp, maxTimestamp, revertingTxHashes)
+func (b *EthAPIBackend) SendBundle(ctx context.Context, txs types.Transactions, blockNumber rpc.BlockNumber, uuid uuid.UUID, signingAddress common.Address, minTimestamp uint64, maxTimestamp uint64, revertingTxHashes []common.Hash) error {
+	return b.eth.txPool.AddMevBundle(txs, big.NewInt(blockNumber.Int64()), uuid, signingAddress, minTimestamp, maxTimestamp, revertingTxHashes)
 }
 
 func (b *EthAPIBackend) GetPoolTransactions() (types.Transactions, error) {

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -326,6 +326,10 @@ func (s *Ethereum) APIs() []rpc.API {
 	}...)
 }
 
+func (s *Ethereum) RegisterBundleFetcher(fetcher core.IFetcher) {
+	s.txPool.RegisterBundleFetcher(fetcher)
+}
+
 func (s *Ethereum) ResetWithGenesisBlock(gb *types.Block) {
 	s.blockchain.ResetWithGenesisBlock(gb)
 }

--- a/flashbotsextra/database.go
+++ b/flashbotsextra/database.go
@@ -41,10 +41,10 @@ func (NilDbService) GetLatestUuidBundles(ctx context.Context, blockNum int64) ([
 type DatabaseService struct {
 	db *sqlx.DB
 
-	insertBuiltBlockStmt      *sqlx.NamedStmt
-	insertMissingBundleStmt   *sqlx.NamedStmt
-	fetchPrioBundlesStmt      *sqlx.NamedStmt
-	fetchGetLatestUuidBundles *sqlx.NamedStmt
+	insertBuiltBlockStmt          *sqlx.NamedStmt
+	insertMissingBundleStmt       *sqlx.NamedStmt
+	fetchPrioBundlesStmt          *sqlx.NamedStmt
+	fetchGetLatestUuidBundlesStmt *sqlx.NamedStmt
 }
 
 func NewDatabaseService(postgresDSN string) (*DatabaseService, error) {
@@ -68,17 +68,17 @@ func NewDatabaseService(postgresDSN string) (*DatabaseService, error) {
 		return nil, err
 	}
 
-	fetchGetLatestUuidBundles, err := db.PrepareNamed("select replacement_uuid, signing_address, bundle_hash from latest_uuid_bundle where target_block_number = :target_block_number")
+	fetchGetLatestUuidBundlesStmt, err := db.PrepareNamed("select replacement_uuid, signing_address, bundle_hash from latest_uuid_bundle where target_block_number = :target_block_number")
 	if err != nil {
 		return nil, err
 	}
 
 	return &DatabaseService{
-		db:                        db,
-		insertBuiltBlockStmt:      insertBuiltBlockStmt,
-		insertMissingBundleStmt:   insertMissingBundleStmt,
-		fetchPrioBundlesStmt:      fetchPrioBundlesStmt,
-		fetchGetLatestUuidBundles: fetchGetLatestUuidBundles,
+		db:                            db,
+		insertBuiltBlockStmt:          insertBuiltBlockStmt,
+		insertMissingBundleStmt:       insertMissingBundleStmt,
+		fetchPrioBundlesStmt:          fetchPrioBundlesStmt,
+		fetchGetLatestUuidBundlesStmt: fetchGetLatestUuidBundlesStmt,
 	}, nil
 }
 
@@ -287,7 +287,7 @@ func (ds *DatabaseService) GetPriorityBundles(ctx context.Context, blockNum int6
 func (ds *DatabaseService) GetLatestUuidBundles(ctx context.Context, blockNum int64) ([]types.LatestUuidBundle, error) {
 	var dstLatestBundles []DbLatestUuidBundle
 	kwArg := map[string]interface{}{"target_block_number": blockNum}
-	if err := ds.fetchGetLatestUuidBundles.SelectContext(ctx, &dstLatestBundles, kwArg); err != nil {
+	if err := ds.fetchGetLatestUuidBundlesStmt.SelectContext(ctx, &dstLatestBundles, kwArg); err != nil {
 		return nil, err
 	}
 	latestBundles := make([]types.LatestUuidBundle, 0, len(dstLatestBundles))

--- a/flashbotsextra/fetcher.go
+++ b/flashbotsextra/fetcher.go
@@ -74,6 +74,10 @@ func (b *bundleFetcher) Run() {
 	go b.fetchAndPush(context.Background(), pushMevBundles)
 }
 
+func (b *bundleFetcher) GetLatestUuidBundles(ctx context.Context, blockNum int64) ([]types.LatestUuidBundle, error) {
+	return b.db.GetLatestUuidBundles(ctx, blockNum)
+}
+
 func (b *bundleFetcher) fetchAndPush(ctx context.Context, pushMevBundles func(bundles []DbBundle)) {
 	var currentBlockNum int64
 	lowPrioBundleTicker := time.NewTicker(time.Second * 2)

--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -47,6 +47,7 @@ import (
 	"github.com/ethereum/go-ethereum/params"
 	"github.com/ethereum/go-ethereum/rlp"
 	"github.com/ethereum/go-ethereum/rpc"
+	"github.com/google/uuid"
 	"github.com/tyler-smith/go-bip39"
 	"golang.org/x/crypto/sha3"
 )
@@ -2061,6 +2062,8 @@ func NewPrivateTxBundleAPI(b Backend) *PrivateTxBundleAPI {
 type SendBundleArgs struct {
 	Txs               []hexutil.Bytes `json:"txs"`
 	BlockNumber       rpc.BlockNumber `json:"blockNumber"`
+	ReplacementUuid   *uuid.UUID      `json:"replacementUuid"`
+	SigningAddress    *common.Address `json:"signingAddress"`
 	MinTimestamp      *uint64         `json:"minTimestamp"`
 	MaxTimestamp      *uint64         `json:"maxTimestamp"`
 	RevertingTxHashes []common.Hash   `json:"revertingTxHashes"`
@@ -2085,6 +2088,16 @@ func (s *PrivateTxBundleAPI) SendBundle(ctx context.Context, args SendBundleArgs
 		txs = append(txs, tx)
 	}
 
+	var replacementUuid uuid.UUID
+	if args.ReplacementUuid != nil {
+		replacementUuid = *args.ReplacementUuid
+	}
+
+	var signingAddress common.Address
+	if args.SigningAddress != nil {
+		signingAddress = *args.SigningAddress
+	}
+
 	var minTimestamp, maxTimestamp uint64
 	if args.MinTimestamp != nil {
 		minTimestamp = *args.MinTimestamp
@@ -2093,7 +2106,7 @@ func (s *PrivateTxBundleAPI) SendBundle(ctx context.Context, args SendBundleArgs
 		maxTimestamp = *args.MaxTimestamp
 	}
 
-	return s.b.SendBundle(ctx, txs, args.BlockNumber, minTimestamp, maxTimestamp, args.RevertingTxHashes)
+	return s.b.SendBundle(ctx, txs, args.BlockNumber, replacementUuid, signingAddress, minTimestamp, maxTimestamp, args.RevertingTxHashes)
 }
 
 // BundleAPI offers an API for accepting bundled transactions

--- a/internal/ethapi/backend.go
+++ b/internal/ethapi/backend.go
@@ -35,6 +35,7 @@ import (
 	"github.com/ethereum/go-ethereum/event"
 	"github.com/ethereum/go-ethereum/params"
 	"github.com/ethereum/go-ethereum/rpc"
+	"github.com/google/uuid"
 )
 
 // Backend interface provides the common API services (that are provided by
@@ -75,7 +76,7 @@ type Backend interface {
 
 	// Transaction pool API
 	SendTx(ctx context.Context, signedTx *types.Transaction, private bool) error
-	SendBundle(ctx context.Context, txs types.Transactions, blockNumber rpc.BlockNumber, minTimestamp uint64, maxTimestamp uint64, revertingTxHashes []common.Hash) error
+	SendBundle(ctx context.Context, txs types.Transactions, blockNumber rpc.BlockNumber, uuid uuid.UUID, signingAddress common.Address, minTimestamp uint64, maxTimestamp uint64, revertingTxHashes []common.Hash) error
 	GetTransaction(ctx context.Context, txHash common.Hash) (*types.Transaction, common.Hash, uint64, uint64, error)
 	GetPoolTransactions() (types.Transactions, error)
 	GetPoolTransaction(txHash common.Hash) *types.Transaction

--- a/internal/ethapi/transaction_args_test.go
+++ b/internal/ethapi/transaction_args_test.go
@@ -38,6 +38,7 @@ import (
 	"github.com/ethereum/go-ethereum/event"
 	"github.com/ethereum/go-ethereum/params"
 	"github.com/ethereum/go-ethereum/rpc"
+	"github.com/google/uuid"
 )
 
 // TestSetFeeDefaults tests the logic for filling in default fee values works as expected.
@@ -216,7 +217,7 @@ func (b *backendMock) SendMegabundle(ctx context.Context, txs types.Transactions
 	return nil
 }
 
-func (b *backendMock) SendBundle(ctx context.Context, txs types.Transactions, blockNumber rpc.BlockNumber, minTimestamp uint64, maxTimestamp uint64, revertingTxHashes []common.Hash) error {
+func (b *backendMock) SendBundle(ctx context.Context, txs types.Transactions, blockNumber rpc.BlockNumber, replacementUuid uuid.UUID, signingAddress common.Address, minTimestamp uint64, maxTimestamp uint64, revertingTxHashes []common.Hash) error {
 	return nil
 }
 

--- a/les/api_backend.go
+++ b/les/api_backend.go
@@ -38,6 +38,7 @@ import (
 	"github.com/ethereum/go-ethereum/light"
 	"github.com/ethereum/go-ethereum/params"
 	"github.com/ethereum/go-ethereum/rpc"
+	"github.com/google/uuid"
 )
 
 type LesApiBackend struct {
@@ -196,8 +197,8 @@ func (b *LesApiBackend) RemoveTx(txHash common.Hash) {
 	b.eth.txPool.RemoveTx(txHash)
 }
 
-func (b *LesApiBackend) SendBundle(ctx context.Context, txs types.Transactions, blockNumber rpc.BlockNumber, minTimestamp uint64, maxTimestamp uint64, revertingTxHashes []common.Hash) error {
-	return b.eth.txPool.AddMevBundle(txs, big.NewInt(blockNumber.Int64()), minTimestamp, maxTimestamp, revertingTxHashes)
+func (b *LesApiBackend) SendBundle(ctx context.Context, txs types.Transactions, blockNumber rpc.BlockNumber, uuid uuid.UUID, signingAddress common.Address, minTimestamp uint64, maxTimestamp uint64, revertingTxHashes []common.Hash) error {
+	return b.eth.txPool.AddMevBundle(txs, big.NewInt(blockNumber.Int64()), uuid, signingAddress, minTimestamp, maxTimestamp, revertingTxHashes)
 }
 
 func (b *LesApiBackend) SendMegabundle(ctx context.Context, txs types.Transactions, blockNumber rpc.BlockNumber, minTimestamp uint64, maxTimestamp uint64, revertingTxHashes []common.Hash, relayAddr common.Address) error {

--- a/light/txpool.go
+++ b/light/txpool.go
@@ -32,6 +32,7 @@ import (
 	"github.com/ethereum/go-ethereum/event"
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/params"
+	"github.com/google/uuid"
 )
 
 const (
@@ -558,6 +559,6 @@ func (pool *TxPool) MevBundles(blockNumber *big.Int, blockTimestamp uint64) ([]t
 }
 
 // AddMevBundle adds a mev bundle to the pool
-func (pool *TxPool) AddMevBundle(txs types.Transactions, blockNumber *big.Int, minTimestamp uint64, maxTimestamp uint64, revertingTxHashes []common.Hash) error {
+func (pool *TxPool) AddMevBundle(txs types.Transactions, blockNumber *big.Int, replacementUuid uuid.UUID, signingAddress common.Address, minTimestamp uint64, maxTimestamp uint64, revertingTxHashes []common.Hash) error {
 	return nil
 }

--- a/miner/contract_simulator_test.go
+++ b/miner/contract_simulator_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/params"
 	tu "github.com/ethereum/go-ethereum/test_utils"
+	"github.com/google/uuid"
 	"github.com/stretchr/testify/require"
 )
 
@@ -266,8 +267,7 @@ func TestSimulatorState(t *testing.T) {
 
 	targetBlockNumber := new(big.Int).Set(b.chain.CurrentHeader().Number)
 	targetBlockNumber.Add(targetBlockNumber, big.NewInt(1))
-	b.txPool.AddMevBundle(types.Transactions{userSwapTx, backrunTx}, targetBlockNumber, 0, 0, nil)
-
+	b.txPool.AddMevBundle(types.Transactions{userSwapTx, backrunTx}, targetBlockNumber, uuid.UUID{}, common.Address{}, 0, 0, nil)
 	buildBlock([]*types.Transaction{}, 3)
 }
 

--- a/miner/worker_test.go
+++ b/miner/worker_test.go
@@ -742,6 +742,7 @@ func TestSimulateBundles(t *testing.T) {
 }
 
 func testBundles(t *testing.T) {
+	// TODO: test cancellations
 	db := rawdb.NewMemoryDatabase()
 	chainConfig := params.AllEthashProtocolChanges
 	engine := ethash.NewFaker()
@@ -820,7 +821,7 @@ func testBundles(t *testing.T) {
 
 		blockNumber := big.NewInt(0).Add(w.chain.CurrentBlock().Number(), big.NewInt(1))
 		for _, bundle := range bundles {
-			err := b.txPool.AddMevBundle(bundle.Txs, blockNumber, 0, 0, nil)
+			err := b.txPool.AddMevBundle(bundle.Txs, blockNumber, types.EmptyUUID, common.Address{}, 0, 0, nil)
 			require.NoError(t, err)
 		}
 


### PR DESCRIPTION
## 📝 Summary

Introduces bundle replacement and cancellation via `replacementUuid`.
Since the replacement is tied to a specific sender, `eth_sendBundle` gets two additional optional fields: the replacement uuid and the signingAddress of the bundle submission.
`func (b *EthAPIBackend) SendBundle(ctx context.Context, txs types.Transactions, blockNumber rpc.BlockNumber, uuid uuid.UUID, signingAddress common.Address, minTimestamp uint64, maxTimestamp uint64, revertingTxHashes []common.Hash) error`.

The DB requests are done in the background, and cancellations are resolved while non-cancelable bundles are already being simulated to avoid waiting for DB to reply.
If anything goes wrong with the cancellations, the cancelable bundles are not considered.

Note: every block is now sent to the relay, as we can no longer rely on the highest-profit rule!

## 📚 References

Cancellations docs: https://github.com/flashbots/flashbots-docs/pull/317/files

---

* [x] I have seen and agree to [`CONTRIBUTING.md`](https://github.com/flashbots/builder/blob/main/CONTRIBUTING.md)
