### PR TITLE
miner: fix mev gas price calc when same nonce tx not in mempool

### DIFF
--- a/miner/worker.go
+++ b/miner/worker.go
@@ -1866,12 +1866,11 @@ func (w *worker) computeBundleGas(env *environment, bundle types.MevBundle, stat
 		}
 
 		txInPendingPool := false
+		txHash := tx.Hash()
 		if accountTxs, ok := pendingTxs[from]; ok {
 			// check if tx is in pending pool
-			txNonce := tx.Nonce()
-
 			for _, accountTx := range accountTxs {
-				if accountTx.Nonce() == txNonce {
+				if accountTx.Hash() == txHash {
 					txInPendingPool = true
 					break
 				}


### PR DESCRIPTION
## 📝 Summary

Currently, if a bundle includes a transaction that has the same sender and nonce as a transaction in the mempool (i.e. attempting to replace a mempool transaction with a bundle transaction), the gas fees from the bundle transaction will not be counted towards the bundle's value.  This PR compares transaction hashes instead of transaction nonces when checking if a bundle transaction is present in the mempool. 

### Motivation

 There are cases when a searcher may want to re-use a nonce from a mempool transaction in a bundle.  For example, a searcher may want to privately replace a pending transaction or move a PGA to a bundle auction.

### Variations

Another approach would be to only count the gas fees if the bundle transaction's effective gas price `(coinbaseDiff + gasFees) / gasUsed` is greater than N% (configured price bump) larger than the mempool transaction's gas price.  This would closely follow the replacement logic of the mempool.

https://github.com/flashbots/builder/blob/8caba1f96ff5adf5647356d231a3dcab8a74fbac/core/tx_list.go#L293-L296

<!--
Another approach would be to only count the difference in effective priority fees when calculating the transaction's contribution to the bundle's value.

 ```
priorityFeeDiff = max(bundleTxEffectivePriorityFee - mempoolTxEffectivePriorityFee, 0) // Lower bound by 0.  
bundleValue += priorityFeeDiff * gasUsed
```
-->

This would avoid allowing "cheap" cancellations/replacements.

---

* [x] I have seen and agree to [`CONTRIBUTING.md`](https://github.com/flashbots/builder/blob/main/CONTRIBUTING.md)
