### PR TITLE
Build on a single head

### DIFF
--- a/builder/beacon_client.go
+++ b/builder/beacon_client.go
@@ -125,42 +125,8 @@ func payloadAttributesMatch(l types.BuilderPayloadAttributes, r types.BuilderPay
 }
 
 func (m *MultiBeaconClient) SubscribeToPayloadAttributesEvents(payloadAttrC chan types.BuilderPayloadAttributes) {
-	clientsChan := make(chan types.BuilderPayloadAttributes, len(m.clients))
 	for _, c := range m.clients {
-		go c.SubscribeToPayloadAttributesEvents(clientsChan)
-	}
-
-	currentSlot := uint64(0)
-	currentSlotPayloadAttributes := []types.BuilderPayloadAttributes{}
-
-	for {
-		select {
-		case <-m.closeCh:
-			return
-		case payloadAttrs := <-clientsChan:
-			if payloadAttrs.Slot < currentSlot {
-				continue
-			} else if payloadAttrs.Slot == currentSlot {
-				shouldSkip := false
-				for _, previousPayloadAttrs := range currentSlotPayloadAttributes {
-					if payloadAttributesMatch(previousPayloadAttrs, payloadAttrs) {
-						shouldSkip = true
-						break
-					}
-				}
-				if shouldSkip {
-					continue
-				}
-
-				payloadAttrC <- payloadAttrs
-				currentSlotPayloadAttributes = append(currentSlotPayloadAttributes, payloadAttrs)
-			} else if payloadAttrs.Slot > currentSlot {
-				currentSlot = payloadAttrs.Slot
-				payloadAttrC <- payloadAttrs
-				currentSlotPayloadAttributes = []types.BuilderPayloadAttributes{payloadAttrs}
-			}
-
-		}
+		go c.SubscribeToPayloadAttributesEvents(payloadAttrC)
 	}
 }
 


### PR DESCRIPTION
## 📝 Summary

Forces building on a single head. With how sse events are set up, as well as how proposers usually act, it's best to ignore blocks coming in after 4 seconds into the slot.
This might change in the future!

## 📚 References

---

* [x] I have seen and agree to [`CONTRIBUTING.md`](https://github.com/flashbots/builder/blob/main/CONTRIBUTING.md)
