### PR TITLE
builder: only build on top of first payload attributes event as it should be canonical

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -26,7 +26,7 @@ jobs:
       uses: actions/checkout@v2
 
     - name: Test
-      run: go test ./core ./miner/... ./internal/ethapi/... ./les/...
+      run: go test ./core ./miner/... ./internal/ethapi/... ./les/... ./builder/... ./eth/block-validation/...
 
     - name: Build
       run: make geth

--- a/README.md
+++ b/README.md
@@ -38,8 +38,9 @@ $ geth --help
     --builder                      (default: false)
           Enable the builder
 
-    --builder.beacon_endpoint value (default: "http://127.0.0.1:5052")
-          Beacon endpoint to connect to for beacon chain data [$BUILDER_BEACON_ENDPOINT]
+    --builder.beacon_endpoints value (default: "http://127.0.0.1:5052")
+          Comma separated list of beacon endpoints to connect to for beacon chain data
+          [$BUILDER_BEACON_ENDPOINTS]
 
     --builder.bellatrix_fork_version value (default: "0x02000000")
           Bellatrix fork version. [$BUILDER_BELLATRIX_FORK_VERSION]
@@ -52,6 +53,10 @@ $ geth --help
 
     --builder.genesis_validators_root value (default: "0x0000000000000000000000000000000000000000000000000000000000000000")
           Genesis validators root of the network. [$BUILDER_GENESIS_VALIDATORS_ROOT]
+
+    --builder.ignore_late_payload_attributes (default: false)
+          Builder will ignore all but the first payload attributes. Use if your CL sends
+          non-canonical head updates.
 
     --builder.listen_addr value    (default: ":28545")
           Listening address for builder endpoint [$BUILDER_LISTEN_ADDR]
@@ -74,11 +79,17 @@ $ geth --help
           missing from the primary remote relay, and to push blocks for registrations
           missing from or matching the primary [$BUILDER_SECONDARY_REMOTE_RELAY_ENDPOINTS]
 
+    --builder.seconds_in_slot value (default: 12)
+          Set the number of seconds in a slot in the local relay
+
     --builder.secret_key value     (default: "0x2fc12ae741f29701f8e30f5de6350766c020cb80768a0ff01e6838ffd2431e11")
           Builder key used for signing blocks [$BUILDER_SECRET_KEY]
 
-    --builder.validation_blacklist value (default: "")
-          Path to file containing blacklisted addresses, json-encoded list of strings.
+    --builder.slots_in_epoch value (default: 32)
+          Set the number of slots in an epoch in the local relay
+
+    --builder.validation_blacklist value
+          Path to file containing blacklisted addresses, json-encoded list of strings
 
     --builder.validator_checks     (default: false)
           Enable the validator checks

--- a/builder/beacon_client.go
+++ b/builder/beacon_client.go
@@ -109,11 +109,10 @@ func (m *MultiBeaconClient) getProposerForNextSlot(requestedSlot uint64) (Pubkey
 
 func payloadAttributesMatch(l types.BuilderPayloadAttributes, r types.BuilderPayloadAttributes) bool {
 	if l.Timestamp != r.Timestamp ||
-		l.Random != r.Random ||
-		l.SuggestedFeeRecipient != r.SuggestedFeeRecipient ||
 		l.Slot != r.Slot ||
-		l.HeadHash != r.HeadHash ||
-		l.GasLimit != r.GasLimit {
+		l.GasLimit != r.GasLimit ||
+		l.Random != r.Random ||
+		l.HeadHash != r.HeadHash {
 		return false
 	}
 

--- a/builder/builder.go
+++ b/builder/builder.go
@@ -52,46 +52,46 @@ type IBuilder interface {
 }
 
 type Builder struct {
-	ds                   flashbotsextra.IDatabaseService
-	relay                IRelay
-	eth                  IEthereumService
-	dryRun               bool
-	validator            *blockvalidation.BlockValidationAPI
-	beaconClient         IBeaconClient
-	builderSecretKey     *bls.SecretKey
-	builderPublicKey     boostTypes.PublicKey
-	builderSigningDomain boostTypes.Domain
+	ds                          flashbotsextra.IDatabaseService
+	relay                       IRelay
+	eth                         IEthereumService
+	dryRun                      bool
+	ignoreLatePayloadAttributes bool
+	validator                   *blockvalidation.BlockValidationAPI
+	beaconClient                IBeaconClient
+	builderSecretKey            *bls.SecretKey
+	builderPublicKey            boostTypes.PublicKey
+	builderSigningDomain        boostTypes.Domain
 
 	limiter *rate.Limiter
 
 	slotMu        sync.Mutex
-	slot          uint64
-	slotAttrs     []types.BuilderPayloadAttributes
+	slotAttrs     types.BuilderPayloadAttributes
 	slotCtx       context.Context
 	slotCtxCancel context.CancelFunc
 
 	stop chan struct{}
 }
 
-func NewBuilder(sk *bls.SecretKey, ds flashbotsextra.IDatabaseService, relay IRelay, builderSigningDomain boostTypes.Domain, eth IEthereumService, dryRun bool, validator *blockvalidation.BlockValidationAPI, beaconClient IBeaconClient) *Builder {
+func NewBuilder(sk *bls.SecretKey, ds flashbotsextra.IDatabaseService, relay IRelay, builderSigningDomain boostTypes.Domain, eth IEthereumService, dryRun bool, ignoreLatePayloadAttributes bool, validator *blockvalidation.BlockValidationAPI, beaconClient IBeaconClient) *Builder {
 	pkBytes := bls.PublicKeyFromSecretKey(sk).Compress()
 	pk := boostTypes.PublicKey{}
 	pk.FromSlice(pkBytes)
 
 	slotCtx, slotCtxCancel := context.WithCancel(context.Background())
 	return &Builder{
-		ds:                   ds,
-		relay:                relay,
-		eth:                  eth,
-		dryRun:               dryRun,
-		validator:            validator,
-		beaconClient:         beaconClient,
-		builderSecretKey:     sk,
-		builderPublicKey:     pk,
-		builderSigningDomain: builderSigningDomain,
+		ds:                          ds,
+		relay:                       relay,
+		eth:                         eth,
+		dryRun:                      dryRun,
+		ignoreLatePayloadAttributes: ignoreLatePayloadAttributes,
+		validator:                   validator,
+		beaconClient:                beaconClient,
+		builderSecretKey:            sk,
+		builderPublicKey:            pk,
+		builderSigningDomain:        builderSigningDomain,
 
 		limiter:       rate.NewLimiter(rate.Every(time.Millisecond), 510),
-		slot:          0,
 		slotCtx:       slotCtx,
 		slotCtxCancel: slotCtxCancel,
 
@@ -116,8 +116,10 @@ func (b *Builder) Start() error {
 				if payloadAttributes.Slot < currentSlot {
 					continue
 				} else if payloadAttributes.Slot == currentSlot {
-					// Ignore all subsequent payloadAttributes until the builder is either ready to build on multiple heads
-					// or CLs only send canonical heads. Expect this behaviour to change.
+					// Subsequent sse events should only be canonical!
+					if !b.ignoreLatePayloadAttributes {
+						b.OnPayloadAttribute(&payloadAttributes)
+					}
 				} else if payloadAttributes.Slot > currentSlot {
 					currentSlot = payloadAttributes.Slot
 					b.OnPayloadAttribute(&payloadAttributes)
@@ -303,25 +305,19 @@ func (b *Builder) OnPayloadAttribute(attrs *types.BuilderPayloadAttributes) erro
 	b.slotMu.Lock()
 	defer b.slotMu.Unlock()
 
-	if b.slot < attrs.Slot {
-		if b.slotCtxCancel != nil {
-			b.slotCtxCancel()
-		}
-
-		slotCtx, slotCtxCancel := context.WithTimeout(context.Background(), 12*time.Second)
-		b.slot = attrs.Slot
-		b.slotAttrs = nil
-		b.slotCtx = slotCtx
-		b.slotCtxCancel = slotCtxCancel
+	if attrs.Equal(&b.slotAttrs) {
+		log.Debug("ignoring known payload attribute", "slot", attrs.Slot, "hash", attrs.HeadHash)
+		return nil
 	}
 
-	for _, currentAttrs := range b.slotAttrs {
-		if attrs.Equal(&currentAttrs) {
-			log.Debug("ignoring known payload attribute", "slot", attrs.Slot, "hash", attrs.HeadHash)
-			return nil
-		}
+	if b.slotCtxCancel != nil {
+		b.slotCtxCancel()
 	}
-	b.slotAttrs = append(b.slotAttrs, *attrs)
+
+	slotCtx, slotCtxCancel := context.WithTimeout(context.Background(), 12*time.Second)
+	b.slotAttrs = *attrs
+	b.slotCtx = slotCtx
+	b.slotCtxCancel = slotCtxCancel
 
 	go b.runBuildingJob(b.slotCtx, proposerPubkey, vd, attrs)
 	return nil

--- a/builder/builder_test.go
+++ b/builder/builder_test.go
@@ -73,7 +73,7 @@ func TestOnPayloadAttributes(t *testing.T) {
 
 	testEthService := &testEthereumService{synced: true, testExecutableData: testExecutableData, testBlock: testBlock, testBlockValue: big.NewInt(10)}
 
-	builder := NewBuilder(sk, flashbotsextra.NilDbService{}, &testRelay, bDomain, testEthService, false, nil, &testBeacon)
+	builder := NewBuilder(sk, flashbotsextra.NilDbService{}, &testRelay, bDomain, testEthService, false, false, nil, &testBeacon)
 	builder.Start()
 	defer builder.Stop()
 

--- a/builder/config.go
+++ b/builder/config.go
@@ -8,6 +8,7 @@ type Config struct {
 	SecondsInSlot                 uint64   `toml:",omitempty"`
 	DisableBundleFetcher          bool     `toml:",omitempty"`
 	DryRun                        bool     `toml:",omitempty"`
+	IgnoreLatePayloadAttributes   bool     `toml:",omitempty"`
 	BuilderSecretKey              string   `toml:",omitempty"`
 	RelaySecretKey                string   `toml:",omitempty"`
 	ListenAddr                    string   `toml:",omitempty"`
@@ -29,6 +30,7 @@ var DefaultConfig = Config{
 	SecondsInSlot:                 12,
 	DisableBundleFetcher:          false,
 	DryRun:                        false,
+	IgnoreLatePayloadAttributes:   false,
 	BuilderSecretKey:              "0x2fc12ae741f29701f8e30f5de6350766c020cb80768a0ff01e6838ffd2431e11",
 	RelaySecretKey:                "0x2fc12ae741f29701f8e30f5de6350766c020cb80768a0ff01e6838ffd2431e11",
 	ListenAddr:                    ":28545",

--- a/builder/local_relay_test.go
+++ b/builder/local_relay_test.go
@@ -32,7 +32,7 @@ func newTestBackend(t *testing.T, forkchoiceData *engine.ExecutableData, block *
 	beaconClient := &testBeaconClient{validator: validator}
 	localRelay := NewLocalRelay(sk, beaconClient, bDomain, cDomain, ForkData{}, true)
 	ethService := &testEthereumService{synced: true, testExecutableData: forkchoiceData, testBlock: block, testBlockValue: blockValue}
-	backend := NewBuilder(sk, flashbotsextra.NilDbService{}, localRelay, bDomain, ethService, false, nil, beaconClient)
+	backend := NewBuilder(sk, flashbotsextra.NilDbService{}, localRelay, bDomain, ethService, false, false, nil, beaconClient)
 	// service := NewService("127.0.0.1:31545", backend)
 
 	backend.limiter = rate.NewLimiter(rate.Inf, 0)

--- a/builder/service.go
+++ b/builder/service.go
@@ -203,7 +203,7 @@ func Register(stack *node.Node, backend *eth.Ethereum, cfg *Config) error {
 		return errors.New("incorrect builder API secret key provided")
 	}
 
-	builderBackend := NewBuilder(builderSk, ds, relay, builderSigningDomain, ethereumService, cfg.DryRun, validator, beaconClient)
+	builderBackend := NewBuilder(builderSk, ds, relay, builderSigningDomain, ethereumService, cfg.DryRun, cfg.IgnoreLatePayloadAttributes, validator, beaconClient)
 	builderService := NewService(cfg.ListenAddr, localRelay, builderBackend)
 
 	stack.RegisterAPIs([]rpc.API{

--- a/cmd/geth/main.go
+++ b/cmd/geth/main.go
@@ -165,6 +165,7 @@ var (
 		utils.BuilderSlotsInEpoch,
 		utils.BuilderDisableBundleFetcher,
 		utils.BuilderDryRun,
+		utils.BuilderIgnoreLatePayloadAttributes,
 		utils.BuilderSecretKey,
 		utils.BuilderRelaySecretKey,
 		utils.BuilderListenAddr,

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -736,6 +736,11 @@ var (
 		Usage:    "Builder only validates blocks without submission to the relay",
 		Category: flags.BuilderCategory,
 	}
+	BuilderIgnoreLatePayloadAttributes = &cli.BoolFlag{
+		Name:     "builder.ignore_late_payload_attributes",
+		Usage:    "Builder will ignore all but the first payload attributes. Use if your CL sends non-canonical head updates.",
+		Category: flags.BuilderCategory,
+	}
 	BuilderSecretKey = &cli.StringFlag{
 		Name:     "builder.secret_key",
 		Usage:    "Builder key used for signing blocks",
@@ -1602,6 +1607,7 @@ func SetBuilderConfig(ctx *cli.Context, cfg *builder.Config) {
 	cfg.SecondsInSlot = ctx.Uint64(BuilderSecondsInSlot.Name)
 	cfg.DisableBundleFetcher = ctx.IsSet(BuilderDisableBundleFetcher.Name)
 	cfg.DryRun = ctx.IsSet(BuilderDryRun.Name)
+	cfg.IgnoreLatePayloadAttributes = ctx.IsSet(BuilderIgnoreLatePayloadAttributes.Name)
 	cfg.BuilderSecretKey = ctx.String(BuilderSecretKey.Name)
 	cfg.RelaySecretKey = ctx.String(BuilderRelaySecretKey.Name)
 	cfg.ListenAddr = ctx.String(BuilderListenAddr.Name)

--- a/miner/multi_worker.go
+++ b/miner/multi_worker.go
@@ -130,6 +130,9 @@ func (w *multiWorker) buildPayload(args *BuildPayloadArgs) (*Payload, error) {
 			block, fees, err := w.getSealingBlock(args.Parent, args.Timestamp, args.FeeRecipient, args.GasLimit, args.Random, args.Withdrawals, false, args.BlockHook)
 			if err == nil {
 				workerPayload.update(block, fees, time.Since(start))
+			} else {
+				log.Error("Error while sealing block", "err", err)
+				workerPayload.Cancel()
 			}
 		}(w)
 	}


### PR DESCRIPTION
## 📝 Summary

Because of how the CL events are set up right now, the builder should ignore subsequent payload attributes calls, as they might be non-canonical. This behaviour on CLs will change in the future and the logic will be adjusted.

## 📚 References

---

* [x] I have seen and agree to [`CONTRIBUTING.md`](https://github.com/flashbots/builder/blob/main/CONTRIBUTING.md)
