### PR TITLE
Add support for additional block building algorithm

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,7 +199,7 @@ Miner is responsible for block creation. Request from the `builder` is routed to
   `proposerTxCommit`. We do it in a way so all fees received by the block builder are sent to the fee recipient.
 * Transaction insertion is done in `fillTransactionsAlgoWorker` \ `fillTransactions`. Depending on the algorithm selected.
   Algo worker (greedy) inserts bundles whenever they belong in the block by effective gas price but default method inserts bundles on top of the block.
-  (see `--miner.algo`)
+  (see `--miner.algotype`)
 * Worker is also responsible for simulating bundles. Bundles are simulated in parallel and results are cached for the particular parent block.
 * `algo_greedy.go` implements logic of the block building. Bundles and transactions are sorted in the order of effective gas price then
   we try to insert everything into to block until gas limit is reached. Failing bundles are reverted during the insertion but txs are not.

--- a/core/types/transaction.go
+++ b/core/types/transaction.go
@@ -713,18 +713,12 @@ func (t *TransactionsByPriceAndNonce) ShiftAndPushByAccountForTx(tx *Transaction
 	}
 
 	acc, _ := Sender(t.signer, tx)
-	txs, ok := t.txs[acc]
-	if !ok || len(txs) < 1 {
-		return
+	if txs, exists := t.txs[acc]; exists && len(txs) > 0 {
+		if wrapped, err := NewTxWithMinerFee(txs[0], t.baseFee); err == nil {
+			t.txs[acc] = txs[1:]
+			heap.Push(&t.heads, wrapped)
+		}
 	}
-
-	wrapped, err := NewTxWithMinerFee(txs[0], t.baseFee)
-	if err != nil || wrapped == nil {
-		return
-	}
-
-	t.txs[acc] = txs[1:]
-	heap.Push(&t.heads, wrapped)
 }
 
 func (t *TransactionsByPriceAndNonce) Push(tx *TxWithMinerFee) {

--- a/core/types/transaction.go
+++ b/core/types/transaction.go
@@ -543,6 +543,22 @@ func (t *TxWithMinerFee) Profit(baseFee *big.Int, gasUsed uint64) *big.Int {
 	}
 }
 
+// SetPrice sets the miner fee of the wrapped transaction.
+func (t *TxWithMinerFee) SetPrice(price *big.Int) {
+	t.minerFee.Set(price)
+}
+
+// SetProfit sets the profit of the wrapped transaction.
+func (t *TxWithMinerFee) SetProfit(profit *big.Int) {
+	if bundle := t.Bundle(); bundle != nil {
+		bundle.TotalEth.Set(profit)
+	} else if sbundle := t.SBundle(); sbundle != nil {
+		sbundle.Profit.Set(profit)
+	} else {
+		panic("SetProfit called on unsupported order type")
+	}
+}
+
 // NewTxWithMinerFee creates a wrapped transaction, calculating the effective
 // miner gasTipCap if a base fee is provided.
 // Returns error in case of a negative effective miner gasTipCap.

--- a/core/types/transaction.go
+++ b/core/types/transaction.go
@@ -683,6 +683,26 @@ func (t *TransactionsByPriceAndNonce) Shift() {
 	heap.Pop(&t.heads)
 }
 
+func (t *TransactionsByPriceAndNonce) ShiftAndPushByAccountForTx(tx *Transaction) {
+	if tx == nil {
+		return
+	}
+
+	acc, _ := Sender(t.signer, tx)
+	txs, ok := t.txs[acc]
+	if !ok || len(txs) < 1 {
+		return
+	}
+
+	wrapped, err := NewTxWithMinerFee(txs[0], t.baseFee)
+	if err != nil || wrapped == nil {
+		return
+	}
+
+	t.txs[acc] = txs[1:]
+	heap.Push(&t.heads, wrapped)
+}
+
 // Pop removes the best transaction, *not* replacing it with the next one from
 // the same account. This should be used when a transaction cannot be executed
 // and hence all subsequent ones should be discarded from the same account.

--- a/core/types/transaction.go
+++ b/core/types/transaction.go
@@ -525,10 +525,14 @@ func (t *TxWithMinerFee) Price() *big.Int {
 	return new(big.Int).Set(t.minerFee)
 }
 
-func (t *TxWithMinerFee) Profit(baseFee *big.Int) *big.Int {
+func (t *TxWithMinerFee) Profit(baseFee *big.Int, gasUsed uint64) *big.Int {
 	if tx := t.Tx(); tx != nil {
 		profit := new(big.Int).Sub(tx.GasPrice(), baseFee)
-		profit.Mul(profit, new(big.Int).SetUint64(tx.Gas()))
+		if gasUsed != 0 {
+			profit.Mul(profit, new(big.Int).SetUint64(gasUsed))
+		} else {
+			profit.Mul(profit, new(big.Int).SetUint64(tx.Gas()))
+		}
 		return profit
 	} else if bundle := t.Bundle(); bundle != nil {
 		return bundle.TotalEth

--- a/core/types/transaction.go
+++ b/core/types/transaction.go
@@ -522,18 +522,16 @@ func (t *TxWithMinerFee) SBundle() *SimSBundle {
 }
 
 func (t *TxWithMinerFee) Price() *big.Int {
-	return t.minerFee
+	return new(big.Int).Set(t.minerFee)
 }
 
 func (t *TxWithMinerFee) Profit() *big.Int {
-	if tx := t.Tx(); tx != nil {
-		return tx.Value()
-	} else if bundle := t.Bundle(); bundle != nil {
+	if bundle := t.Bundle(); bundle != nil {
 		return bundle.TotalEth
 	} else if sbundle := t.SBundle(); sbundle != nil {
 		return sbundle.Profit
 	} else {
-		return big.NewInt(0)
+		panic("profit called on unsupported order type")
 	}
 }
 

--- a/core/types/transaction.go
+++ b/core/types/transaction.go
@@ -525,6 +525,18 @@ func (t *TxWithMinerFee) Price() *big.Int {
 	return t.minerFee
 }
 
+func (t *TxWithMinerFee) Profit() *big.Int {
+	if tx := t.Tx(); tx != nil {
+		return tx.Value()
+	} else if bundle := t.Bundle(); bundle != nil {
+		return bundle.TotalEth
+	} else if sbundle := t.SBundle(); sbundle != nil {
+		return sbundle.Profit
+	} else {
+		return big.NewInt(0)
+	}
+}
+
 // NewTxWithMinerFee creates a wrapped transaction, calculating the effective
 // miner gasTipCap if a base fee is provided.
 // Returns error in case of a negative effective miner gasTipCap.

--- a/core/types/transaction.go
+++ b/core/types/transaction.go
@@ -521,6 +521,10 @@ func (t *TxWithMinerFee) SBundle() *SimSBundle {
 	return t.order.AsSBundle()
 }
 
+func (t *TxWithMinerFee) Price() *big.Int {
+	return t.minerFee
+}
+
 // NewTxWithMinerFee creates a wrapped transaction, calculating the effective
 // miner gasTipCap if a base fee is provided.
 // Returns error in case of a negative effective miner gasTipCap.
@@ -536,7 +540,7 @@ func NewTxWithMinerFee(tx *Transaction, baseFee *big.Int) (*TxWithMinerFee, erro
 }
 
 // NewBundleWithMinerFee creates a wrapped bundle.
-func NewBundleWithMinerFee(bundle *SimulatedBundle, baseFee *big.Int) (*TxWithMinerFee, error) {
+func NewBundleWithMinerFee(bundle *SimulatedBundle, _ *big.Int) (*TxWithMinerFee, error) {
 	minerFee := bundle.MevGasPrice
 	return &TxWithMinerFee{
 		order:    _BundleOrder{bundle},
@@ -545,7 +549,7 @@ func NewBundleWithMinerFee(bundle *SimulatedBundle, baseFee *big.Int) (*TxWithMi
 }
 
 // NewSBundleWithMinerFee creates a wrapped bundle.
-func NewSBundleWithMinerFee(sbundle *SimSBundle, baseFee *big.Int) (*TxWithMinerFee, error) {
+func NewSBundleWithMinerFee(sbundle *SimSBundle, _ *big.Int) (*TxWithMinerFee, error) {
 	minerFee := sbundle.MevGasPrice
 	return &TxWithMinerFee{
 		order:    _SBundleOrder{sbundle},

--- a/core/types/transaction.go
+++ b/core/types/transaction.go
@@ -687,6 +687,12 @@ func (t *TransactionsByPriceAndNonce) Shift() {
 	heap.Pop(&t.heads)
 }
 
+// ShiftAndPushByAccountForTx attempts to update the transaction list associated with a given account address
+// based on the input transaction account. If the associated account exists and has additional transactions,
+// the top of the transaction list is popped and pushed to the heap.
+// Note that this operation should only be performed when the head transaction on the heap is different from the
+// input transaction. This operation is useful in scenarios where the current best head transaction for an account
+// was already popped from the heap and we want to process the next one from the same account.
 func (t *TransactionsByPriceAndNonce) ShiftAndPushByAccountForTx(tx *Transaction) {
 	if tx == nil {
 		return

--- a/miner/algo_common.go
+++ b/miner/algo_common.go
@@ -273,11 +273,12 @@ func (envDiff *environmentDiff) commitBundle(bundle *types.SimulatedBundle, chDa
 	if enforceProfit {
 		// if profit is enforced between simulation and actual commit, only allow >-1% divergence
 		simulatedBundleProfit := bundle.TotalEth
-		actualBundleGasFees := new(big.Int).Mul(bundleActualEffGP, big.NewInt(int64(gasUsed)))
-		actualBundleProfit := new(big.Int).Add(coinbaseBalanceDelta, actualBundleGasFees)
+		actualBundleProfit := bundleProfit
 
-		simulatedBundleProfit.Mul(simulatedBundleProfit, common.Big100)
-		actualBundleProfit.Mul(actualBundleProfit, big.NewInt(99))
+		// We want to make simulated profit smaller to allow for some leeway in cases where the actual profit is
+		// lower due to transaction ordering
+		simulatedBundleProfit.Mul(simulatedBundleProfit, big.NewInt(99))
+		actualBundleProfit.Mul(actualBundleProfit, common.Big100)
 
 		if simulatedBundleProfit.Cmp(actualBundleProfit) == 1 {
 			log.Trace("Lower bundle profit found after inclusion", "bundle", bundle.OriginalBundle.Hash)
@@ -446,11 +447,12 @@ func (envDiff *environmentDiff) commitSBundle(b *types.SimSBundle, chData chainD
 	if enforceProfit {
 		// if profit is enforced between simulation and actual commit, only allow >-1% divergence
 		simulatedProfit := b.Profit
-		actualGasFees := new(big.Int).Mul(gasDelta, gotEGP)
-		actualProfit := new(big.Int).Add(coinbaseDelta, actualGasFees)
+		actualProfit := coinbaseDelta
 
-		simulatedProfit.Mul(simulatedProfit, common.Big100)
-		actualProfit.Mul(actualProfit, big.NewInt(99))
+		// We want to make simulated profit smaller to allow for some leeway in cases where the actual profit is
+		// lower due to transaction ordering
+		simulatedProfit.Mul(simulatedProfit, big.NewInt(99))
+		actualProfit.Mul(actualProfit, common.Big100)
 
 		if simulatedProfit.Cmp(actualProfit) == 1 {
 			log.Trace("Lower sbundle profit found after inclusion", "sbundle", b.Bundle.Hash())

--- a/miner/algo_common.go
+++ b/miner/algo_common.go
@@ -273,7 +273,7 @@ func (envDiff *environmentDiff) commitBundle(bundle *types.SimulatedBundle, chDa
 	if enforceProfit {
 		// if profit is enforced between simulation and actual commit, only allow >-1% divergence
 		simulatedBundleProfit := bundle.TotalEth
-		actualBundleGasFees := new(big.Int).Mul(bundleActualEffGP, new(big.Int).SetUint64(gasUsed))
+		actualBundleGasFees := new(big.Int).Mul(bundleActualEffGP, big.NewInt(int64(gasUsed)))
 		actualBundleProfit := new(big.Int).Add(coinbaseBalanceDelta, actualBundleGasFees)
 
 		simulatedBundleProfit.Mul(simulatedBundleProfit, common.Big100)

--- a/miner/algo_common.go
+++ b/miner/algo_common.go
@@ -272,15 +272,16 @@ func (envDiff *environmentDiff) commitBundle(bundle *types.SimulatedBundle, chDa
 
 	if enforceProfit {
 		// if profit is enforced between simulation and actual commit, only allow >-1% divergence
-		simulatedBundleProfit := bundle.TotalEth
-		actualBundleProfit := bundleProfit
+		simulatedBundleProfit := new(big.Int).Set(bundle.TotalEth)
+		actualBundleGasFees := new(big.Int).Mul(bundleActualEffGP, big.NewInt(int64(gasUsed)))
+		actualBundleProfit := new(big.Int).Add(coinbaseBalanceDelta, actualBundleGasFees)
 
 		// We want to make simulated profit smaller to allow for some leeway in cases where the actual profit is
 		// lower due to transaction ordering
 		simulatedBundleProfit.Mul(simulatedBundleProfit, big.NewInt(99))
 		actualBundleProfit.Mul(actualBundleProfit, common.Big100)
 
-		if simulatedBundleProfit.Cmp(actualBundleProfit) == 1 {
+		if simulatedBundleProfit.Cmp(actualBundleProfit) > 0 {
 			log.Trace("Lower bundle profit found after inclusion", "bundle", bundle.OriginalBundle.Hash)
 			return errors.New("bundle profit too low")
 		}
@@ -446,15 +447,15 @@ func (envDiff *environmentDiff) commitSBundle(b *types.SimSBundle, chData chainD
 
 	if enforceProfit {
 		// if profit is enforced between simulation and actual commit, only allow >-1% divergence
-		simulatedProfit := b.Profit
-		actualProfit := coinbaseDelta
+		simulatedProfit := new(big.Int).Set(b.Profit)
+		actualProfit := new(big.Int).Set(coinbaseDelta)
 
 		// We want to make simulated profit smaller to allow for some leeway in cases where the actual profit is
 		// lower due to transaction ordering
 		simulatedProfit.Mul(simulatedProfit, big.NewInt(99))
 		actualProfit.Mul(actualProfit, common.Big100)
 
-		if simulatedProfit.Cmp(actualProfit) == 1 {
+		if simulatedProfit.Cmp(actualProfit) > 0 {
 			log.Trace("Lower sbundle profit found after inclusion", "sbundle", b.Bundle.Hash())
 			return errors.New("sbundle profit too low")
 		}

--- a/miner/algo_common.go
+++ b/miner/algo_common.go
@@ -273,12 +273,11 @@ func (envDiff *environmentDiff) commitBundle(bundle *types.SimulatedBundle, chDa
 	if enforceProfit {
 		// if profit is enforced between simulation and actual commit, only allow >-1% divergence
 		simulatedBundleProfit := new(big.Int).Set(bundle.TotalEth)
-		actualBundleGasFees := new(big.Int).Mul(bundleActualEffGP, big.NewInt(int64(gasUsed)))
-		actualBundleProfit := new(big.Int).Add(coinbaseBalanceDelta, actualBundleGasFees)
+		actualBundleProfit := new(big.Int).Mul(bundleActualEffGP, big.NewInt(int64(gasUsed)))
 
 		// We want to make simulated profit smaller to allow for some leeway in cases where the actual profit is
 		// lower due to transaction ordering
-		simulatedBundleProfit.Mul(simulatedBundleProfit, big.NewInt(99))
+		simulatedBundleProfit.Mul(simulatedBundleProfit, big.NewInt(95))
 		actualBundleProfit.Mul(actualBundleProfit, common.Big100)
 
 		if simulatedBundleProfit.Cmp(actualBundleProfit) > 0 {
@@ -452,7 +451,7 @@ func (envDiff *environmentDiff) commitSBundle(b *types.SimSBundle, chData chainD
 
 		// We want to make simulated profit smaller to allow for some leeway in cases where the actual profit is
 		// lower due to transaction ordering
-		simulatedProfit.Mul(simulatedProfit, big.NewInt(99))
+		simulatedProfit.Mul(simulatedProfit, big.NewInt(95))
 		actualProfit.Mul(actualProfit, common.Big100)
 
 		if simulatedProfit.Cmp(actualProfit) > 0 {

--- a/miner/algo_common.go
+++ b/miner/algo_common.go
@@ -161,31 +161,31 @@ func (envDiff *environmentDiff) commitTx(tx *types.Transaction, chData chainData
 			// Pop the current out-of-gas transaction without shifting in the next from the account
 			from, _ := types.Sender(signer, tx)
 			log.Trace("Gas limit exceeded for current block", "sender", from)
-			return nil, popTx, err
+			return receipt, popTx, err
 
 		case errors.Is(err, core.ErrNonceTooLow):
 			// New head notification data race between the transaction pool and miner, shift
 			from, _ := types.Sender(signer, tx)
 			log.Trace("Skipping transaction with low nonce", "sender", from, "nonce", tx.Nonce())
-			return nil, shiftTx, err
+			return receipt, shiftTx, err
 
 		case errors.Is(err, core.ErrNonceTooHigh):
 			// Reorg notification data race between the transaction pool and miner, skip account =
 			from, _ := types.Sender(signer, tx)
 			log.Trace("Skipping account with hight nonce", "sender", from, "nonce", tx.Nonce())
-			return nil, popTx, err
+			return receipt, popTx, err
 
 		case errors.Is(err, core.ErrTxTypeNotSupported):
 			// Pop the unsupported transaction without shifting in the next from the account
 			from, _ := types.Sender(signer, tx)
 			log.Trace("Skipping unsupported transaction type", "sender", from, "type", tx.Type())
-			return nil, popTx, err
+			return receipt, popTx, err
 
 		default:
 			// Strange error, discard the transaction and get the next in line (note, the
 			// nonce-too-high clause will prevent us from executing in vain).
 			log.Trace("Transaction failed, account skipped", "hash", tx.Hash(), "err", err)
-			return nil, shiftTx, err
+			return receipt, shiftTx, err
 		}
 	}
 

--- a/miner/algo_common_test.go
+++ b/miner/algo_common_test.go
@@ -523,7 +523,7 @@ func TestGetSealingWorkAlgos(t *testing.T) {
 		testConfig.AlgoType = ALGO_MEV_GETH
 	})
 
-	for _, algoType := range []AlgoType{ALGO_MEV_GETH, ALGO_GREEDY} {
+	for _, algoType := range []AlgoType{ALGO_MEV_GETH, ALGO_GREEDY, ALGO_GREEDY_BUCKETS} {
 		local := new(params.ChainConfig)
 		*local = *ethashChainConfig
 		local.TerminalTotalDifficulty = big.NewInt(0)
@@ -538,7 +538,7 @@ func TestGetSealingWorkAlgosWithProfit(t *testing.T) {
 		testConfig.BuilderTxSigningKey = nil
 	})
 
-	for _, algoType := range []AlgoType{ALGO_GREEDY} {
+	for _, algoType := range []AlgoType{ALGO_GREEDY, ALGO_GREEDY_BUCKETS} {
 		var err error
 		testConfig.BuilderTxSigningKey, err = crypto.GenerateKey()
 		require.NoError(t, err)

--- a/miner/algo_common_test.go
+++ b/miner/algo_common_test.go
@@ -241,7 +241,7 @@ func TestTxCommit(t *testing.T) {
 
 	tx := signers.signTx(1, 21000, big.NewInt(0), big.NewInt(1), signers.addresses[2], big.NewInt(0), []byte{})
 
-	receipt, i, err := envDiff.commitTx(tx, chData, defaultValidationConfig)
+	receipt, i, err := envDiff.commitTx(tx, chData)
 	if err != nil {
 		t.Fatal("can't commit transaction:", err)
 	}
@@ -298,7 +298,7 @@ func TestBundleCommit(t *testing.T) {
 		t.Fatal("Failed to simulate bundle", err)
 	}
 
-	err = envDiff.commitBundle(&simBundle, chData, nil, defaultValidationConfig)
+	err = envDiff.commitBundle(&simBundle, chData, nil, defaultAlgorithmConfig)
 	if err != nil {
 		t.Fatal("Failed to commit bundle", err)
 	}
@@ -323,7 +323,7 @@ func TestErrorTxCommit(t *testing.T) {
 	signers.nonces[1] = 10
 	tx := signers.signTx(1, 21000, big.NewInt(0), big.NewInt(1), signers.addresses[2], big.NewInt(0), []byte{})
 
-	_, i, err := envDiff.commitTx(tx, chData, defaultValidationConfig)
+	_, i, err := envDiff.commitTx(tx, chData)
 	if err == nil {
 		t.Fatal("committed incorrect transaction:", err)
 	}
@@ -357,7 +357,7 @@ func TestCommitTxOverGasLimit(t *testing.T) {
 	tx1 := signers.signTx(1, 21000, big.NewInt(0), big.NewInt(1), signers.addresses[2], big.NewInt(0), []byte{})
 	tx2 := signers.signTx(1, 21000, big.NewInt(0), big.NewInt(1), signers.addresses[2], big.NewInt(0), []byte{})
 
-	receipt, i, err := envDiff.commitTx(tx1, chData, defaultValidationConfig)
+	receipt, i, err := envDiff.commitTx(tx1, chData)
 	if err != nil {
 		t.Fatal("can't commit transaction:", err)
 	}
@@ -372,7 +372,7 @@ func TestCommitTxOverGasLimit(t *testing.T) {
 		t.Fatal("Env diff gas pool is not drained")
 	}
 
-	_, _, err = envDiff.commitTx(tx2, chData, defaultValidationConfig)
+	_, _, err = envDiff.commitTx(tx2, chData)
 	require.Error(t, err, "committed tx over gas limit")
 }
 
@@ -398,7 +398,7 @@ func TestErrorBundleCommit(t *testing.T) {
 		t.Fatal("Failed to simulate bundle", err)
 	}
 
-	_, _, err = envDiff.commitTx(tx0, chData, defaultValidationConfig)
+	_, _, err = envDiff.commitTx(tx0, chData)
 	if err != nil {
 		t.Fatal("Failed to commit tx0", err)
 	}
@@ -408,7 +408,7 @@ func TestErrorBundleCommit(t *testing.T) {
 	newProfitBefore := new(big.Int).Set(envDiff.newProfit)
 	balanceBefore := envDiff.state.GetBalance(signers.addresses[2])
 
-	err = envDiff.commitBundle(&simBundle, chData, nil, defaultValidationConfig)
+	err = envDiff.commitBundle(&simBundle, chData, nil, defaultAlgorithmConfig)
 	if err == nil {
 		t.Fatal("Committed failed bundle", err)
 	}
@@ -456,13 +456,13 @@ func TestBlacklist(t *testing.T) {
 	balanceBefore := envDiff.state.GetBalance(signers.addresses[3])
 
 	tx := signers.signTx(1, 21000, big.NewInt(0), big.NewInt(1), signers.addresses[3], big.NewInt(77), []byte{})
-	_, _, err := envDiff.commitTx(tx, chData, defaultValidationConfig)
+	_, _, err := envDiff.commitTx(tx, chData)
 	if err == nil {
 		t.Fatal("committed blacklisted transaction: to")
 	}
 
 	tx = signers.signTx(3, 21000, big.NewInt(0), big.NewInt(1), signers.addresses[1], big.NewInt(88), []byte{})
-	_, _, err = envDiff.commitTx(tx, chData, defaultValidationConfig)
+	_, _, err = envDiff.commitTx(tx, chData)
 	if err == nil {
 		t.Fatal("committed blacklisted transaction: sender")
 	}
@@ -471,19 +471,19 @@ func TestBlacklist(t *testing.T) {
 	calldata = append(calldata, signers.addresses[3].Bytes()...)
 
 	tx = signers.signTx(4, 40000, big.NewInt(0), big.NewInt(1), payProxyAddress, big.NewInt(99), calldata)
-	_, _, err = envDiff.commitTx(tx, chData, defaultValidationConfig)
+	_, _, err = envDiff.commitTx(tx, chData)
 	if err == nil {
 		t.Fatal("committed blacklisted transaction: trace")
 	}
 
 	tx = signers.signTx(5, 40000, big.NewInt(0), big.NewInt(1), payProxyAddress, big.NewInt(0), calldata)
-	_, _, err = envDiff.commitTx(tx, chData, defaultValidationConfig)
+	_, _, err = envDiff.commitTx(tx, chData)
 	if err == nil {
 		t.Fatal("committed blacklisted transaction: trace, zero value")
 	}
 
 	tx = signers.signTx(6, 30000, big.NewInt(0), big.NewInt(1), payProxyAddress, big.NewInt(99), calldata)
-	_, _, err = envDiff.commitTx(tx, chData, defaultValidationConfig)
+	_, _, err = envDiff.commitTx(tx, chData)
 	if err == nil {
 		t.Fatal("committed blacklisted transaction: trace, failed tx")
 	}

--- a/miner/algo_common_test.go
+++ b/miner/algo_common_test.go
@@ -298,7 +298,7 @@ func TestBundleCommit(t *testing.T) {
 		t.Fatal("Failed to simulate bundle", err)
 	}
 
-	err = envDiff.commitBundle(&simBundle, chData, nil)
+	err = envDiff.commitBundle(&simBundle, chData, nil, false)
 	if err != nil {
 		t.Fatal("Failed to commit bundle", err)
 	}
@@ -408,7 +408,7 @@ func TestErrorBundleCommit(t *testing.T) {
 	newProfitBefore := new(big.Int).Set(envDiff.newProfit)
 	balanceBefore := envDiff.state.GetBalance(signers.addresses[2])
 
-	err = envDiff.commitBundle(&simBundle, chData, nil)
+	err = envDiff.commitBundle(&simBundle, chData, nil, false)
 	if err == nil {
 		t.Fatal("Committed failed bundle", err)
 	}

--- a/miner/algo_common_test.go
+++ b/miner/algo_common_test.go
@@ -241,7 +241,7 @@ func TestTxCommit(t *testing.T) {
 
 	tx := signers.signTx(1, 21000, big.NewInt(0), big.NewInt(1), signers.addresses[2], big.NewInt(0), []byte{})
 
-	receipt, i, err := envDiff.commitTx(tx, chData)
+	receipt, i, err := envDiff.commitTx(tx, chData, defaultValidationConfig)
 	if err != nil {
 		t.Fatal("can't commit transaction:", err)
 	}
@@ -298,7 +298,7 @@ func TestBundleCommit(t *testing.T) {
 		t.Fatal("Failed to simulate bundle", err)
 	}
 
-	err = envDiff.commitBundle(&simBundle, chData, nil, false)
+	err = envDiff.commitBundle(&simBundle, chData, nil, defaultValidationConfig)
 	if err != nil {
 		t.Fatal("Failed to commit bundle", err)
 	}
@@ -323,7 +323,7 @@ func TestErrorTxCommit(t *testing.T) {
 	signers.nonces[1] = 10
 	tx := signers.signTx(1, 21000, big.NewInt(0), big.NewInt(1), signers.addresses[2], big.NewInt(0), []byte{})
 
-	_, i, err := envDiff.commitTx(tx, chData)
+	_, i, err := envDiff.commitTx(tx, chData, defaultValidationConfig)
 	if err == nil {
 		t.Fatal("committed incorrect transaction:", err)
 	}
@@ -357,7 +357,7 @@ func TestCommitTxOverGasLimit(t *testing.T) {
 	tx1 := signers.signTx(1, 21000, big.NewInt(0), big.NewInt(1), signers.addresses[2], big.NewInt(0), []byte{})
 	tx2 := signers.signTx(1, 21000, big.NewInt(0), big.NewInt(1), signers.addresses[2], big.NewInt(0), []byte{})
 
-	receipt, i, err := envDiff.commitTx(tx1, chData)
+	receipt, i, err := envDiff.commitTx(tx1, chData, defaultValidationConfig)
 	if err != nil {
 		t.Fatal("can't commit transaction:", err)
 	}
@@ -372,7 +372,7 @@ func TestCommitTxOverGasLimit(t *testing.T) {
 		t.Fatal("Env diff gas pool is not drained")
 	}
 
-	_, _, err = envDiff.commitTx(tx2, chData)
+	_, _, err = envDiff.commitTx(tx2, chData, defaultValidationConfig)
 	require.Error(t, err, "committed tx over gas limit")
 }
 
@@ -398,7 +398,7 @@ func TestErrorBundleCommit(t *testing.T) {
 		t.Fatal("Failed to simulate bundle", err)
 	}
 
-	_, _, err = envDiff.commitTx(tx0, chData)
+	_, _, err = envDiff.commitTx(tx0, chData, defaultValidationConfig)
 	if err != nil {
 		t.Fatal("Failed to commit tx0", err)
 	}
@@ -408,7 +408,7 @@ func TestErrorBundleCommit(t *testing.T) {
 	newProfitBefore := new(big.Int).Set(envDiff.newProfit)
 	balanceBefore := envDiff.state.GetBalance(signers.addresses[2])
 
-	err = envDiff.commitBundle(&simBundle, chData, nil, false)
+	err = envDiff.commitBundle(&simBundle, chData, nil, defaultValidationConfig)
 	if err == nil {
 		t.Fatal("Committed failed bundle", err)
 	}
@@ -456,13 +456,13 @@ func TestBlacklist(t *testing.T) {
 	balanceBefore := envDiff.state.GetBalance(signers.addresses[3])
 
 	tx := signers.signTx(1, 21000, big.NewInt(0), big.NewInt(1), signers.addresses[3], big.NewInt(77), []byte{})
-	_, _, err := envDiff.commitTx(tx, chData)
+	_, _, err := envDiff.commitTx(tx, chData, defaultValidationConfig)
 	if err == nil {
 		t.Fatal("committed blacklisted transaction: to")
 	}
 
 	tx = signers.signTx(3, 21000, big.NewInt(0), big.NewInt(1), signers.addresses[1], big.NewInt(88), []byte{})
-	_, _, err = envDiff.commitTx(tx, chData)
+	_, _, err = envDiff.commitTx(tx, chData, defaultValidationConfig)
 	if err == nil {
 		t.Fatal("committed blacklisted transaction: sender")
 	}
@@ -471,19 +471,19 @@ func TestBlacklist(t *testing.T) {
 	calldata = append(calldata, signers.addresses[3].Bytes()...)
 
 	tx = signers.signTx(4, 40000, big.NewInt(0), big.NewInt(1), payProxyAddress, big.NewInt(99), calldata)
-	_, _, err = envDiff.commitTx(tx, chData)
+	_, _, err = envDiff.commitTx(tx, chData, defaultValidationConfig)
 	if err == nil {
 		t.Fatal("committed blacklisted transaction: trace")
 	}
 
 	tx = signers.signTx(5, 40000, big.NewInt(0), big.NewInt(1), payProxyAddress, big.NewInt(0), calldata)
-	_, _, err = envDiff.commitTx(tx, chData)
+	_, _, err = envDiff.commitTx(tx, chData, defaultValidationConfig)
 	if err == nil {
 		t.Fatal("committed blacklisted transaction: trace, zero value")
 	}
 
 	tx = signers.signTx(6, 30000, big.NewInt(0), big.NewInt(1), payProxyAddress, big.NewInt(99), calldata)
-	_, _, err = envDiff.commitTx(tx, chData)
+	_, _, err = envDiff.commitTx(tx, chData, defaultValidationConfig)
 	if err == nil {
 		t.Fatal("committed blacklisted transaction: trace, failed tx")
 	}

--- a/miner/algo_greedy.go
+++ b/miner/algo_greedy.go
@@ -120,12 +120,11 @@ func (b *greedyBuilder) mergeGreedyBuckets(envDiff *environmentDiff, orders *typ
 		usedBundles       []types.SimulatedBundle
 		usedSbundles      []types.UsedSBundle
 		transactionBucket []*types.TxWithMinerFee
-		basePercent       = new(big.Int).SetUint64(90)
-		denominator       = new(big.Int).SetUint64(100)
-		percent           = new(big.Int).Div(basePercent, denominator)
+		percent           = new(big.Float).SetFloat64(0.9)
 
 		InitializeBucket = func(order *types.TxWithMinerFee) [1]*big.Int {
-			bucketMin := new(big.Int).Mul(order.Price(), percent)
+			floorPrice := new(big.Float).Mul(new(big.Float).SetInt(order.Price()), percent)
+			bucketMin, _ := floorPrice.Int(nil)
 			return [1]*big.Int{bucketMin}
 		}
 
@@ -145,7 +144,6 @@ func (b *greedyBuilder) mergeGreedyBuckets(envDiff *environmentDiff, orders *typ
 				continue // re-run since committing transactions may have pushed higher nonce transactions back into heap
 			}
 			// TODO: don't break if there are still retryable transactions
-			// TODO: need to apply bucketed transactions after heap is empty
 			break
 		}
 

--- a/miner/algo_greedy.go
+++ b/miner/algo_greedy.go
@@ -48,7 +48,7 @@ func (b *greedyBuilder) mergeOrdersIntoEnvDiff(
 		}
 
 		if tx := order.Tx(); tx != nil {
-			receipt, skip, err := envDiff.commitTx(tx, b.chainData, defaultValidationConfig)
+			receipt, skip, err := envDiff.commitTx(tx, b.chainData)
 			switch skip {
 			case shiftTx:
 				orders.Shift()
@@ -66,7 +66,7 @@ func (b *greedyBuilder) mergeOrdersIntoEnvDiff(
 			}
 		} else if bundle := order.Bundle(); bundle != nil {
 			//log.Debug("buildBlock considering bundle", "egp", bundle.MevGasPrice.String(), "hash", bundle.OriginalBundle.Hash)
-			err := envDiff.commitBundle(bundle, b.chainData, b.interrupt, defaultValidationConfig)
+			err := envDiff.commitBundle(bundle, b.chainData, b.interrupt, defaultAlgorithmConfig)
 			orders.Pop()
 			if err != nil {
 				log.Trace("Could not apply bundle", "bundle", bundle.OriginalBundle.Hash, "err", err)
@@ -79,7 +79,7 @@ func (b *greedyBuilder) mergeOrdersIntoEnvDiff(
 			usedEntry := types.UsedSBundle{
 				Bundle: sbundle.Bundle,
 			}
-			err := envDiff.commitSBundle(sbundle, b.chainData, b.interrupt, b.builderKey, defaultValidationConfig)
+			err := envDiff.commitSBundle(sbundle, b.chainData, b.interrupt, b.builderKey, defaultAlgorithmConfig)
 			orders.Pop()
 			if err != nil {
 				log.Trace("Could not apply sbundle", "bundle", sbundle.Bundle.Hash(), "err", err)

--- a/miner/algo_greedy.go
+++ b/miner/algo_greedy.go
@@ -48,7 +48,7 @@ func (b *greedyBuilder) mergeOrdersIntoEnvDiff(
 		}
 
 		if tx := order.Tx(); tx != nil {
-			receipt, skip, err := envDiff.commitTx(tx, b.chainData)
+			receipt, skip, err := envDiff.commitTx(tx, b.chainData, defaultValidationConfig)
 			switch skip {
 			case shiftTx:
 				orders.Shift()
@@ -66,7 +66,7 @@ func (b *greedyBuilder) mergeOrdersIntoEnvDiff(
 			}
 		} else if bundle := order.Bundle(); bundle != nil {
 			//log.Debug("buildBlock considering bundle", "egp", bundle.MevGasPrice.String(), "hash", bundle.OriginalBundle.Hash)
-			err := envDiff.commitBundle(bundle, b.chainData, b.interrupt, false)
+			err := envDiff.commitBundle(bundle, b.chainData, b.interrupt, defaultValidationConfig)
 			orders.Pop()
 			if err != nil {
 				log.Trace("Could not apply bundle", "bundle", bundle.OriginalBundle.Hash, "err", err)
@@ -79,7 +79,7 @@ func (b *greedyBuilder) mergeOrdersIntoEnvDiff(
 			usedEntry := types.UsedSBundle{
 				Bundle: sbundle.Bundle,
 			}
-			err := envDiff.commitSBundle(sbundle, b.chainData, b.interrupt, b.builderKey, false)
+			err := envDiff.commitSBundle(sbundle, b.chainData, b.interrupt, b.builderKey, defaultValidationConfig)
 			orders.Pop()
 			if err != nil {
 				log.Trace("Could not apply sbundle", "bundle", sbundle.Bundle.Hash(), "err", err)

--- a/miner/algo_greedy.go
+++ b/miner/algo_greedy.go
@@ -2,9 +2,6 @@ package miner
 
 import (
 	"crypto/ecdsa"
-	"math/big"
-	"sort"
-
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core"
 	"github.com/ethereum/go-ethereum/core/types"
@@ -22,147 +19,18 @@ type greedyBuilder struct {
 	chainData        chainData
 	builderKey       *ecdsa.PrivateKey
 	interrupt        *int32
-	algoType         AlgoType
 }
 
 func newGreedyBuilder(
 	chain *core.BlockChain, chainConfig *params.ChainConfig,
-	blacklist map[common.Address]struct{}, env *environment, key *ecdsa.PrivateKey, interrupt *int32, algo AlgoType,
+	blacklist map[common.Address]struct{}, env *environment, key *ecdsa.PrivateKey, interrupt *int32,
 ) *greedyBuilder {
 	return &greedyBuilder{
 		inputEnvironment: env,
 		chainData:        chainData{chainConfig, chain, blacklist},
 		builderKey:       key,
 		interrupt:        interrupt,
-		algoType:         algo,
 	}
-}
-
-func (b *greedyBuilder) commit(
-	envDiff *environmentDiff, transactions []*types.TxWithMinerFee, orders *types.TransactionsByPriceAndNonce,
-) ([]types.SimulatedBundle, []types.UsedSBundle) {
-	var (
-		usedBundles  []types.SimulatedBundle
-		usedSbundles []types.UsedSBundle
-	)
-
-	for _, order := range transactions {
-		if tx := order.Tx(); tx != nil {
-			receipt, skip, err := envDiff.commitTx(tx, b.chainData)
-			if skip == shiftTx {
-				orders.ShiftAndPushByAccountForTx(tx)
-			}
-
-			if err != nil {
-				log.Trace("could not apply tx", "hash", tx.Hash(), "err", err)
-				// TODO: handle retry
-				continue
-			}
-
-			effGapPrice, err := tx.EffectiveGasTip(envDiff.baseEnvironment.header.BaseFee)
-			if err == nil {
-				log.Trace("Included tx", "EGP", effGapPrice.String(), "gasUsed", receipt.GasUsed)
-			}
-		} else if bundle := order.Bundle(); bundle != nil {
-			err := envDiff.commitBundle(bundle, b.chainData, b.interrupt, true)
-			if err != nil {
-				log.Trace("Could not apply bundle", "bundle", bundle.OriginalBundle.Hash, "err", err)
-				// TODO: handle retry
-				continue
-			}
-
-			log.Trace("Included bundle", "bundleEGP", bundle.MevGasPrice.String(),
-				"gasUsed", bundle.TotalGasUsed, "ethToCoinbase", ethIntToFloat(bundle.TotalEth))
-			usedBundles = append(usedBundles, *bundle)
-		} else if sbundle := order.SBundle(); sbundle != nil {
-			usedEntry := types.UsedSBundle{
-				Bundle: sbundle.Bundle,
-			}
-			err := envDiff.commitSBundle(sbundle, b.chainData, b.interrupt, b.builderKey, true)
-			if err != nil {
-				log.Trace("Could not apply sbundle", "bundle", sbundle.Bundle.Hash(), "err", err)
-				// TODO: handle retry
-				usedEntry.Success = false
-				usedSbundles = append(usedSbundles, usedEntry)
-				continue
-			}
-
-			log.Trace("Included sbundle", "bundleEGP", sbundle.MevGasPrice.String(), "ethToCoinbase", ethIntToFloat(sbundle.Profit))
-			usedEntry.Success = true
-			usedSbundles = append(usedSbundles, usedEntry)
-		}
-	}
-	return usedBundles, usedSbundles
-}
-
-func (b *greedyBuilder) mergeGreedyBuckets(
-	envDiff *environmentDiff, orders *types.TransactionsByPriceAndNonce) (
-	[]types.SimulatedBundle, []types.UsedSBundle,
-) {
-	if orders.Peek() == nil {
-		return nil, nil
-	}
-
-	var (
-		usedBundles       []types.SimulatedBundle
-		usedSbundles      []types.UsedSBundle
-		transactionBucket []*types.TxWithMinerFee
-		percent           = big.NewFloat(0.9)
-
-		InitializeBucket = func(order *types.TxWithMinerFee) [1]*big.Int {
-			floorPrice := new(big.Float).Mul(new(big.Float).SetInt(order.Price()), percent)
-			round, _ := floorPrice.Int64()
-			return [1]*big.Int{big.NewInt(round)}
-		}
-
-		IsOrderInPriceRange = func(order *types.TxWithMinerFee, minPrice *big.Int) bool {
-			return order.Price().Cmp(minPrice) > -1
-		}
-
-		SortByProfit = func(transactions []*types.TxWithMinerFee) {
-			sort.SliceStable(transactions, func(i, j int) bool {
-				var (
-					iProfit = transactions[i].Profit()
-					jProfit = transactions[j].Profit()
-				)
-
-				return iProfit.Cmp(jProfit) > 0
-			})
-		}
-	)
-
-	bucket := InitializeBucket(orders.Peek())
-	for {
-		order := orders.Peek()
-		if order == nil {
-			if len(transactionBucket) != 0 {
-				SortByProfit(transactionBucket)
-				bundles, sbundles := b.commit(envDiff, transactionBucket, orders)
-				usedBundles = append(usedBundles, bundles...)
-				usedSbundles = append(usedSbundles, sbundles...)
-				transactionBucket = nil
-				continue // re-run since committing transactions may have pushed higher nonce transactions back into heap
-			}
-			// TODO: don't break if there are still retryable transactions
-			break
-		}
-
-		if ok := IsOrderInPriceRange(order, bucket[0]); ok {
-			orders.Pop()
-			transactionBucket = append(transactionBucket, order)
-		} else {
-			if len(transactionBucket) != 0 {
-				SortByProfit(transactionBucket)
-				bundles, sbundles := b.commit(envDiff, transactionBucket, orders)
-				usedBundles = append(usedBundles, bundles...)
-				usedSbundles = append(usedSbundles, sbundles...)
-				transactionBucket = nil
-			}
-			bucket = InitializeBucket(order)
-		}
-	}
-
-	return usedBundles, usedSbundles
 }
 
 func (b *greedyBuilder) mergeGreedy(envDiff *environmentDiff, orders *types.TransactionsByPriceAndNonce) ([]types.SimulatedBundle, []types.UsedSBundle) {
@@ -228,14 +96,63 @@ func (b *greedyBuilder) mergeGreedy(envDiff *environmentDiff, orders *types.Tran
 
 func (b *greedyBuilder) mergeOrdersIntoEnvDiff(
 	envDiff *environmentDiff, orders *types.TransactionsByPriceAndNonce) ([]types.SimulatedBundle, []types.UsedSBundle) {
-	switch b.algoType {
-	case ALGO_GREEDY_BUCKETS:
-		return b.mergeGreedyBuckets(envDiff, orders)
-	case ALGO_GREEDY:
-		fallthrough
-	default:
-		return b.mergeGreedy(envDiff, orders)
+	var (
+		usedBundles  []types.SimulatedBundle
+		usedSbundles []types.UsedSBundle
+	)
+	for {
+		order := orders.Peek()
+		if order == nil {
+			break
+		}
+
+		if tx := order.Tx(); tx != nil {
+			receipt, skip, err := envDiff.commitTx(tx, b.chainData)
+			switch skip {
+			case shiftTx:
+				orders.Shift()
+			case popTx:
+				orders.Pop()
+			}
+
+			if err != nil {
+				log.Trace("could not apply tx", "hash", tx.Hash(), "err", err)
+				continue
+			}
+			effGapPrice, err := tx.EffectiveGasTip(envDiff.baseEnvironment.header.BaseFee)
+			if err == nil {
+				log.Trace("Included tx", "EGP", effGapPrice.String(), "gasUsed", receipt.GasUsed)
+			}
+		} else if bundle := order.Bundle(); bundle != nil {
+			//log.Debug("buildBlock considering bundle", "egp", bundle.MevGasPrice.String(), "hash", bundle.OriginalBundle.Hash)
+			err := envDiff.commitBundle(bundle, b.chainData, b.interrupt, false)
+			orders.Pop()
+			if err != nil {
+				log.Trace("Could not apply bundle", "bundle", bundle.OriginalBundle.Hash, "err", err)
+				continue
+			}
+
+			log.Trace("Included bundle", "bundleEGP", bundle.MevGasPrice.String(), "gasUsed", bundle.TotalGasUsed, "ethToCoinbase", ethIntToFloat(bundle.TotalEth))
+			usedBundles = append(usedBundles, *bundle)
+		} else if sbundle := order.SBundle(); sbundle != nil {
+			usedEntry := types.UsedSBundle{
+				Bundle: sbundle.Bundle,
+			}
+			err := envDiff.commitSBundle(sbundle, b.chainData, b.interrupt, b.builderKey, false)
+			orders.Pop()
+			if err != nil {
+				log.Trace("Could not apply sbundle", "bundle", sbundle.Bundle.Hash(), "err", err)
+				usedEntry.Success = false
+				usedSbundles = append(usedSbundles, usedEntry)
+				continue
+			}
+
+			log.Trace("Included sbundle", "bundleEGP", sbundle.MevGasPrice.String(), "ethToCoinbase", ethIntToFloat(sbundle.Profit))
+			usedEntry.Success = true
+			usedSbundles = append(usedSbundles, usedEntry)
+		}
 	}
+	return usedBundles, usedSbundles
 }
 
 func (b *greedyBuilder) buildBlock(simBundles []types.SimulatedBundle, simSBundles []*types.SimSBundle, transactions map[common.Address]types.Transactions) (*environment, []types.SimulatedBundle, []types.UsedSBundle) {

--- a/miner/algo_greedy.go
+++ b/miner/algo_greedy.go
@@ -2,6 +2,8 @@ package miner
 
 import (
 	"crypto/ecdsa"
+	"math/big"
+	"sort"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core"
@@ -29,6 +31,172 @@ func newGreedyBuilder(chain *core.BlockChain, chainConfig *params.ChainConfig, b
 		builderKey:       key,
 		interrupt:        interrupt,
 	}
+}
+
+func sortTransactionsByProfit(transactions []*types.TxWithMinerFee) []*types.TxWithMinerFee {
+	sort.SliceStable(transactions, func(i, j int) bool {
+		if transactions[i].Tx() != nil {
+			return false
+		}
+
+		if transactions[j].Tx() != nil {
+			return false
+		}
+
+		var iProfit, jProfit *big.Int
+		if iBundle := transactions[i].Bundle(); iBundle != nil {
+			iProfit = iBundle.TotalEth
+		} else if iSBundle := transactions[i].SBundle(); iSBundle != nil {
+			iProfit = iSBundle.Profit
+		}
+
+		if jBundle := transactions[j].Bundle(); jBundle != nil {
+			jProfit = jBundle.TotalEth
+		} else if jSBundle := transactions[j].SBundle(); jSBundle != nil {
+			jProfit = jSBundle.Profit
+		}
+
+		return iProfit.Cmp(jProfit) > 0
+	})
+
+	return transactions
+}
+
+func (b *greedyBuilder) commit(envDiff *environmentDiff, transactions []*types.TxWithMinerFee, orders *types.TransactionsByPriceAndNonce) {
+	for _, order := range transactions {
+		if tx := order.Tx(); tx != nil {
+			receipt, skip, err := envDiff.commitTx(tx, b.chainData)
+			if skip == shiftTx {
+				orders.ShiftAndPushByAccountForTx(tx)
+			}
+
+			if err != nil {
+				log.Trace("could not apply tx", "hash", tx.Hash(), "err", err)
+				// TODO: handle retry
+				continue
+			}
+
+			effGapPrice, err := tx.EffectiveGasTip(envDiff.baseEnvironment.header.BaseFee)
+			if err == nil {
+				log.Trace("Included tx", "EGP", effGapPrice.String(), "gasUsed", receipt.GasUsed)
+			}
+		} else if bundle := order.Bundle(); bundle != nil {
+			err := envDiff.commitBundle(bundle, b.chainData, b.interrupt)
+			if err != nil {
+				log.Trace("Could not apply bundle", "bundle", bundle.OriginalBundle.Hash, "err", err)
+				// TODO: handle retry
+				continue
+			}
+
+			log.Trace("Included bundle", "bundleEGP", bundle.MevGasPrice.String(), "gasUsed", bundle.TotalGasUsed, "ethToCoinbase", ethIntToFloat(bundle.TotalEth))
+			//usedBundles = append(usedBundles, *bundle)
+		} else if sbundle := order.SBundle(); sbundle != nil {
+			usedEntry := types.UsedSBundle{
+				Bundle: sbundle.Bundle,
+			}
+			err := envDiff.commitSBundle(sbundle, b.chainData, b.interrupt, b.builderKey)
+			if err != nil {
+				log.Trace("Could not apply sbundle", "bundle", sbundle.Bundle.Hash(), "err", err)
+				// TODO: handle retry
+				usedEntry.Success = false
+				//usedSbundles = append(usedSbundles, usedEntry)
+				continue
+			}
+
+			log.Trace("Included sbundle", "bundleEGP", sbundle.MevGasPrice.String(), "ethToCoinbase", ethIntToFloat(sbundle.Profit))
+			usedEntry.Success = true
+			//usedSbundles = append(usedSbundles, usedEntry)
+		}
+	}
+}
+
+func (b *greedyBuilder) mergeGreedyBuckets(envDiff *environmentDiff, orders *types.TransactionsByPriceAndNonce) (
+	[]types.SimulatedBundle, []types.UsedSBundle) {
+	if orders == nil {
+		return nil, nil
+	}
+
+	if orders.Peek() == nil {
+		return nil, nil
+	}
+
+	type TransactionList struct {
+		ProfitSortedTransactions []*types.TxWithMinerFee
+	}
+
+	var (
+		buckets      = make([]*big.Int, 10)
+		bucketIndex  int
+		usedBundles  []types.SimulatedBundle
+		usedSbundles []types.UsedSBundle
+		txList       TransactionList
+		basePercent  = new(big.Int).SetInt64(10)
+		denominator  = new(big.Int).SetInt64(100)
+
+		Price = func(order *types.TxWithMinerFee) (price *big.Int) {
+			if tx := order.Tx(); tx != nil {
+				egp, err := tx.EffectiveGasTip(envDiff.baseEnvironment.header.BaseFee)
+				if err != nil {
+					return
+				}
+
+				price.Set(egp)
+			} else if bundle := order.Bundle(); bundle != nil {
+				price.Set(bundle.MevGasPrice)
+			} else if sbundle := order.SBundle(); sbundle != nil {
+				price.Set(sbundle.MevGasPrice)
+			}
+
+			return
+		}
+
+		InitializeBuckets = func(orders *types.TransactionsByPriceAndNonce) {
+			var (
+				peek    = orders.Peek()
+				highest = Price(peek)
+				size    = len(buckets)
+			)
+			for i := range buckets {
+				multiplier := new(big.Int).SetInt64(int64(i + 1))    // e.g. 1..10
+				percent := new(big.Int).Mul(basePercent, multiplier) // e.g. 10*9
+				percent.Div(percent, denominator)                    // e.g. 90/100
+				bucketMax := new(big.Int).Mul(highest, percent)      // e.g. 100 * 0.9
+
+				buckets[size-i+1] = bucketMax
+			}
+
+			// instead of [100, 90, 80, ... , 10] we want [90, 80, 70, ... , 0] for easier comparison
+			buckets = buckets[1:]
+			buckets = append(buckets, new(big.Int).SetInt64(0))
+		}
+
+		IsOrderInPriceRange = func(order *types.TxWithMinerFee) bool {
+			return Price(order).Cmp(buckets[bucketIndex]) > 0
+		}
+	)
+
+	InitializeBuckets(orders)
+	for {
+		order := orders.Peek()
+		if order == nil {
+			// TODO: don't break if there are still retryable transactions
+
+			// TODO: need to apply bucketed transactions after heap is empty
+			break
+		}
+
+		if ok := IsOrderInPriceRange(order); ok {
+			orders.Pop()
+			txList.ProfitSortedTransactions = append(txList.ProfitSortedTransactions, order)
+		} else {
+			txList.ProfitSortedTransactions = sortTransactionsByProfit(txList.ProfitSortedTransactions)
+			b.commit(envDiff, txList.ProfitSortedTransactions, orders)
+			txList.ProfitSortedTransactions = nil
+			bucketIndex++
+		}
+	}
+
+	return usedBundles, usedSbundles
 }
 
 func (b *greedyBuilder) mergeOrdersIntoEnvDiff(envDiff *environmentDiff, orders *types.TransactionsByPriceAndNonce) ([]types.SimulatedBundle, []types.UsedSBundle) {

--- a/miner/algo_greedy.go
+++ b/miner/algo_greedy.go
@@ -35,7 +35,8 @@ func newGreedyBuilder(
 }
 
 func (b *greedyBuilder) mergeOrdersIntoEnvDiff(
-	envDiff *environmentDiff, orders *types.TransactionsByPriceAndNonce) ([]types.SimulatedBundle, []types.UsedSBundle) {
+	envDiff *environmentDiff, orders *types.TransactionsByPriceAndNonce) ([]types.SimulatedBundle, []types.UsedSBundle,
+) {
 	var (
 		usedBundles  []types.SimulatedBundle
 		usedSbundles []types.UsedSBundle

--- a/miner/algo_greedy.go
+++ b/miner/algo_greedy.go
@@ -64,7 +64,7 @@ func (b *greedyBuilder) commit(
 				log.Trace("Included tx", "EGP", effGapPrice.String(), "gasUsed", receipt.GasUsed)
 			}
 		} else if bundle := order.Bundle(); bundle != nil {
-			err := envDiff.commitBundle(bundle, b.chainData, b.interrupt)
+			err := envDiff.commitBundle(bundle, b.chainData, b.interrupt, true)
 			if err != nil {
 				log.Trace("Could not apply bundle", "bundle", bundle.OriginalBundle.Hash, "err", err)
 				// TODO: handle retry
@@ -78,7 +78,7 @@ func (b *greedyBuilder) commit(
 			usedEntry := types.UsedSBundle{
 				Bundle: sbundle.Bundle,
 			}
-			err := envDiff.commitSBundle(sbundle, b.chainData, b.interrupt, b.builderKey)
+			err := envDiff.commitSBundle(sbundle, b.chainData, b.interrupt, b.builderKey, true)
 			if err != nil {
 				log.Trace("Could not apply sbundle", "bundle", sbundle.Bundle.Hash(), "err", err)
 				// TODO: handle retry
@@ -195,7 +195,7 @@ func (b *greedyBuilder) mergeGreedy(envDiff *environmentDiff, orders *types.Tran
 			}
 		} else if bundle := order.Bundle(); bundle != nil {
 			//log.Debug("buildBlock considering bundle", "egp", bundle.MevGasPrice.String(), "hash", bundle.OriginalBundle.Hash)
-			err := envDiff.commitBundle(bundle, b.chainData, b.interrupt)
+			err := envDiff.commitBundle(bundle, b.chainData, b.interrupt, false)
 			orders.Pop()
 			if err != nil {
 				log.Trace("Could not apply bundle", "bundle", bundle.OriginalBundle.Hash, "err", err)
@@ -208,7 +208,7 @@ func (b *greedyBuilder) mergeGreedy(envDiff *environmentDiff, orders *types.Tran
 			usedEntry := types.UsedSBundle{
 				Bundle: sbundle.Bundle,
 			}
-			err := envDiff.commitSBundle(sbundle, b.chainData, b.interrupt, b.builderKey)
+			err := envDiff.commitSBundle(sbundle, b.chainData, b.interrupt, b.builderKey, false)
 			orders.Pop()
 			if err != nil {
 				log.Trace("Could not apply sbundle", "bundle", sbundle.Bundle.Hash(), "err", err)

--- a/miner/algo_greedy_buckets.go
+++ b/miner/algo_greedy_buckets.go
@@ -2,13 +2,14 @@ package miner
 
 import (
 	"crypto/ecdsa"
+	"math/big"
+	"sort"
+
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/params"
-	"math/big"
-	"sort"
 )
 
 // / To use it:
@@ -160,9 +161,10 @@ func (b *greedyBucketsBuilder) mergeOrdersIntoEnvDiff(
 				usedBundles = append(usedBundles, bundles...)
 				usedSbundles = append(usedSbundles, sbundles...)
 				transactions = nil
-				continue // re-run since committing transactions may have pushed higher nonce transactions back into heap
+				// re-run since committing transactions may have pushed higher nonce transactions, or previously
+				// failed transactions back into orders heap
+				continue
 			}
-			// TODO: don't break if there are still retryable transactions
 			break
 		}
 

--- a/miner/algo_greedy_buckets.go
+++ b/miner/algo_greedy_buckets.go
@@ -141,7 +141,7 @@ func (b *greedyBucketsBuilder) mergeOrdersIntoEnvDiff(
 		}
 
 		IsOrderInPriceRange = func(order *types.TxWithMinerFee, minPrice *big.Int) bool {
-			return order.Price().Cmp(minPrice) > -1
+			return order.Price().Cmp(minPrice) >= 0
 		}
 
 		SortInPlaceByProfit = func(baseFee *big.Int, transactions []*types.TxWithMinerFee) {

--- a/miner/algo_greedy_buckets.go
+++ b/miner/algo_greedy_buckets.go
@@ -1,0 +1,162 @@
+package miner
+
+import (
+	"crypto/ecdsa"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/log"
+	"github.com/ethereum/go-ethereum/params"
+	"math/big"
+	"sort"
+)
+
+// / To use it:
+// / 1. Copy relevant data from the worker
+// / 2. Call buildBlock
+// / 2. If new bundles, txs arrive, call buildBlock again
+// / This struct lifecycle is tied to 1 block-building task
+type greedyBucketsBuilder struct {
+	inputEnvironment *environment
+	chainData        chainData
+	builderKey       *ecdsa.PrivateKey
+	interrupt        *int32
+}
+
+func newGreedyBucketsBuilder(
+	chain *core.BlockChain, chainConfig *params.ChainConfig,
+	blacklist map[common.Address]struct{}, env *environment, key *ecdsa.PrivateKey, interrupt *int32,
+) *greedyBucketsBuilder {
+	return &greedyBucketsBuilder{
+		inputEnvironment: env,
+		chainData:        chainData{chainConfig: chainConfig, chain: chain, blacklist: blacklist},
+		builderKey:       key,
+		interrupt:        interrupt,
+	}
+}
+
+func (b *greedyBucketsBuilder) commit(envDiff *environmentDiff, transactions []*types.TxWithMinerFee, orders *types.TransactionsByPriceAndNonce) ([]types.SimulatedBundle, []types.UsedSBundle) {
+	var (
+		usedBundles  []types.SimulatedBundle
+		usedSbundles []types.UsedSBundle
+	)
+
+	for _, order := range transactions {
+		if tx := order.Tx(); tx != nil {
+			receipt, skip, err := envDiff.commitTx(tx, b.chainData)
+			if skip == shiftTx {
+				orders.ShiftAndPushByAccountForTx(tx)
+			}
+
+			if err != nil {
+				log.Trace("could not apply tx", "hash", tx.Hash(), "err", err)
+				// TODO: handle retry
+				continue
+			}
+
+			effGapPrice, err := tx.EffectiveGasTip(envDiff.baseEnvironment.header.BaseFee)
+			if err == nil {
+				log.Trace("Included tx", "EGP", effGapPrice.String(), "gasUsed", receipt.GasUsed)
+			}
+		} else if bundle := order.Bundle(); bundle != nil {
+			err := envDiff.commitBundle(bundle, b.chainData, b.interrupt, true)
+			if err != nil {
+				log.Trace("Could not apply bundle", "bundle", bundle.OriginalBundle.Hash, "err", err)
+				// TODO: handle retry
+				continue
+			}
+
+			log.Trace("Included bundle", "bundleEGP", bundle.MevGasPrice.String(),
+				"gasUsed", bundle.TotalGasUsed, "ethToCoinbase", ethIntToFloat(bundle.TotalEth))
+			usedBundles = append(usedBundles, *bundle)
+		} else if sbundle := order.SBundle(); sbundle != nil {
+			usedEntry := types.UsedSBundle{
+				Bundle: sbundle.Bundle,
+			}
+			err := envDiff.commitSBundle(sbundle, b.chainData, b.interrupt, b.builderKey, true)
+			if err != nil {
+				log.Trace("Could not apply sbundle", "bundle", sbundle.Bundle.Hash(), "err", err)
+				// TODO: handle retry
+				usedEntry.Success = false
+				usedSbundles = append(usedSbundles, usedEntry)
+				continue
+			}
+
+			log.Trace("Included sbundle", "bundleEGP", sbundle.MevGasPrice.String(), "ethToCoinbase", ethIntToFloat(sbundle.Profit))
+			usedEntry.Success = true
+			usedSbundles = append(usedSbundles, usedEntry)
+		}
+	}
+	return usedBundles, usedSbundles
+}
+
+func (b *greedyBucketsBuilder) mergeOrdersIntoEnvDiff(
+	envDiff *environmentDiff, orders *types.TransactionsByPriceAndNonce) ([]types.SimulatedBundle, []types.UsedSBundle) {
+	if orders.Peek() == nil {
+		return nil, nil
+	}
+
+	var (
+		usedBundles       []types.SimulatedBundle
+		usedSbundles      []types.UsedSBundle
+		transactionBucket []*types.TxWithMinerFee
+		percent           = big.NewFloat(0.9)
+
+		InitializeBucket = func(order *types.TxWithMinerFee) [1]*big.Int {
+			floorPrice := new(big.Float).Mul(new(big.Float).SetInt(order.Price()), percent)
+			round, _ := floorPrice.Int64()
+			return [1]*big.Int{big.NewInt(round)}
+		}
+
+		IsOrderInPriceRange = func(order *types.TxWithMinerFee, minPrice *big.Int) bool {
+			return order.Price().Cmp(minPrice) > -1
+		}
+
+		SortInPlaceByProfit = func(transactions []*types.TxWithMinerFee) {
+			sort.SliceStable(transactions, func(i, j int) bool {
+				return transactions[i].Profit().Cmp(transactions[j].Profit()) > 0
+			})
+		}
+	)
+
+	bucket := InitializeBucket(orders.Peek())
+	for {
+		order := orders.Peek()
+		if order == nil {
+			if len(transactionBucket) != 0 {
+				SortInPlaceByProfit(transactionBucket)
+				bundles, sbundles := b.commit(envDiff, transactionBucket, orders)
+				usedBundles = append(usedBundles, bundles...)
+				usedSbundles = append(usedSbundles, sbundles...)
+				transactionBucket = nil
+				continue // re-run since committing transactions may have pushed higher nonce transactions back into heap
+			}
+			// TODO: don't break if there are still retryable transactions
+			break
+		}
+
+		if ok := IsOrderInPriceRange(order, bucket[0]); ok {
+			orders.Pop()
+			transactionBucket = append(transactionBucket, order)
+		} else {
+			if len(transactionBucket) != 0 {
+				SortInPlaceByProfit(transactionBucket)
+				bundles, sbundles := b.commit(envDiff, transactionBucket, orders)
+				usedBundles = append(usedBundles, bundles...)
+				usedSbundles = append(usedSbundles, sbundles...)
+				transactionBucket = nil
+			}
+			bucket = InitializeBucket(order)
+		}
+	}
+
+	return usedBundles, usedSbundles
+}
+
+func (b *greedyBucketsBuilder) buildBlock(simBundles []types.SimulatedBundle, simSBundles []*types.SimSBundle, transactions map[common.Address]types.Transactions) (*environment, []types.SimulatedBundle, []types.UsedSBundle) {
+	orders := types.NewTransactionsByPriceAndNonce(b.inputEnvironment.signer, transactions, simBundles, simSBundles, b.inputEnvironment.header.BaseFee)
+	envDiff := newEnvironmentDiff(b.inputEnvironment.copy())
+	usedBundles, usedSbundles := b.mergeOrdersIntoEnvDiff(envDiff, orders)
+	envDiff.applyToBaseEnv()
+	return envDiff.baseEnvironment, usedBundles, usedSbundles
+}

--- a/miner/algo_greedy_buckets.go
+++ b/miner/algo_greedy_buckets.go
@@ -45,7 +45,7 @@ func (b *greedyBucketsBuilder) commit(envDiff *environmentDiff,
 		usedBundles                []types.SimulatedBundle
 		usedSbundles               []types.UsedSBundle
 		CheckRetryOrderAndReinsert = func(order *types.TxWithMinerFee, orders *types.TransactionsByPriceAndNonce, retryMap map[*types.TxWithMinerFee]int, retryLimit int) {
-			var isRetryable bool
+			var isRetryable bool = false
 			if retryCount, exists := retryMap[order]; exists {
 				if retryCount != retryLimit {
 					isRetryable = true
@@ -119,7 +119,7 @@ func (b *greedyBucketsBuilder) mergeOrdersIntoEnvDiff(
 	}
 
 	const (
-		retryLimit = 2
+		retryLimit = 1
 	)
 
 	var (

--- a/miner/algo_greedy_buckets.go
+++ b/miner/algo_greedy_buckets.go
@@ -44,7 +44,10 @@ func (b *greedyBucketsBuilder) commit(envDiff *environmentDiff,
 	var (
 		usedBundles                []types.SimulatedBundle
 		usedSbundles               []types.UsedSBundle
-		CheckRetryOrderAndReinsert = func(order *types.TxWithMinerFee, orders *types.TransactionsByPriceAndNonce, retryMap map[*types.TxWithMinerFee]int, retryLimit int) {
+		CheckRetryOrderAndReinsert = func(
+			order *types.TxWithMinerFee, orders *types.TransactionsByPriceAndNonce,
+			retryMap map[*types.TxWithMinerFee]int, retryLimit int,
+		) {
 			var isRetryable bool = false
 			if retryCount, exists := retryMap[order]; exists {
 				if retryCount != retryLimit {

--- a/miner/algo_greedy_buckets.go
+++ b/miner/algo_greedy_buckets.go
@@ -107,6 +107,10 @@ func (b *greedyBucketsBuilder) commit(envDiff *environmentDiff,
 			log.Trace("Included sbundle", "bundleEGP", sbundle.MevGasPrice.String(), "ethToCoinbase", ethIntToFloat(sbundle.Profit))
 			usedEntry.Success = true
 			usedSbundles = append(usedSbundles, usedEntry)
+		} else {
+			// note: this should never happen because we should not be inserting invalid transaction types into
+			// the orders heap
+			panic("unsupported order type found")
 		}
 	}
 	return usedBundles, usedSbundles

--- a/miner/algo_greedy_test.go
+++ b/miner/algo_greedy_test.go
@@ -27,8 +27,16 @@ func TestBuildBlockGasLimit(t *testing.T) {
 			signers.signTx(3, 21000, big.NewInt(math.MaxInt), big.NewInt(math.MaxInt), signers.addresses[2], big.NewInt(math.MaxInt), []byte{}),
 		}
 
-		builder := newGreedyBuilder(chData.chain, chData.chainConfig, nil, env, nil, nil, algo)
-		result, _, _ := builder.buildBlock([]types.SimulatedBundle{}, nil, txs)
+		var result *environment
+		switch algo {
+		case ALGO_GREEDY_BUCKETS:
+			builder := newGreedyBuilder(chData.chain, chData.chainConfig, nil, env, nil, nil)
+			result, _, _ = builder.buildBlock([]types.SimulatedBundle{}, nil, txs)
+		case ALGO_GREEDY:
+			builder := newGreedyBucketsBuilder(chData.chain, chData.chainConfig, nil, env, nil, nil)
+			result, _, _ = builder.buildBlock([]types.SimulatedBundle{}, nil, txs)
+		}
+
 		t.Log("block built", "txs", len(result.txs), "gasPool", result.gasPool.Gas(), "algorithm", algo.String())
 		if result.tcount != 1 {
 			t.Fatalf("Incorrect tx count [found: %d]", result.tcount)

--- a/miner/algo_greedy_test.go
+++ b/miner/algo_greedy_test.go
@@ -2,34 +2,37 @@ package miner
 
 import (
 	"fmt"
+	"math"
 	"math/big"
 	"testing"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
-	"github.com/ethereum/go-ethereum/log"
 )
 
 func TestBuildBlockGasLimit(t *testing.T) {
-	statedb, chData, signers := genTestSetup()
+	algos := []AlgoType{ALGO_GREEDY, ALGO_GREEDY_BUCKETS}
+	for _, algo := range algos {
+		statedb, chData, signers := genTestSetup()
+		env := newEnvironment(chData, statedb, signers.addresses[0], 21000, big.NewInt(1))
+		txs := make(map[common.Address]types.Transactions)
 
-	env := newEnvironment(chData, statedb, signers.addresses[0], 21000, big.NewInt(1))
+		txs[signers.addresses[1]] = types.Transactions{
+			signers.signTx(1, 21000, big.NewInt(0), big.NewInt(1), signers.addresses[2], big.NewInt(0), []byte{}),
+		}
+		txs[signers.addresses[2]] = types.Transactions{
+			signers.signTx(2, 21000, big.NewInt(0), big.NewInt(1), signers.addresses[2], big.NewInt(0), []byte{}),
+		}
+		txs[signers.addresses[3]] = types.Transactions{
+			signers.signTx(3, 21000, big.NewInt(math.MaxInt), big.NewInt(math.MaxInt), signers.addresses[2], big.NewInt(math.MaxInt), []byte{}),
+		}
 
-	txs := make(map[common.Address]types.Transactions)
-
-	txs[signers.addresses[1]] = types.Transactions{
-		signers.signTx(1, 21000, big.NewInt(0), big.NewInt(1), signers.addresses[2], big.NewInt(0), []byte{}),
-	}
-	txs[signers.addresses[2]] = types.Transactions{
-		signers.signTx(2, 21000, big.NewInt(0), big.NewInt(1), signers.addresses[2], big.NewInt(0), []byte{}),
-	}
-
-	builder := newGreedyBuilder(chData.chain, chData.chainConfig, nil, env, nil, nil)
-
-	result, _, _ := builder.buildBlock([]types.SimulatedBundle{}, nil, txs)
-	log.Info("block built", "txs", len(result.txs), "gasPool", result.gasPool.Gas())
-	if result.tcount != 1 {
-		t.Fatal("Incorrect tx count")
+		builder := newGreedyBuilder(chData.chain, chData.chainConfig, nil, env, nil, nil, algo)
+		result, _, _ := builder.buildBlock([]types.SimulatedBundle{}, nil, txs)
+		t.Log("block built", "txs", len(result.txs), "gasPool", result.gasPool.Gas(), "algorithm", algo.String())
+		if result.tcount != 1 {
+			t.Fatalf("Incorrect tx count [found: %d]", result.tcount)
+		}
 	}
 }
 

--- a/miner/algo_greedy_test.go
+++ b/miner/algo_greedy_test.go
@@ -33,7 +33,7 @@ func TestBuildBlockGasLimit(t *testing.T) {
 			builder := newGreedyBuilder(chData.chain, chData.chainConfig, nil, env, nil, nil)
 			result, _, _ = builder.buildBlock([]types.SimulatedBundle{}, nil, txs)
 		case ALGO_GREEDY:
-			builder := newGreedyBucketsBuilder(chData.chain, chData.chainConfig, nil, env, nil, nil)
+			builder := newGreedyBucketsBuilder(chData.chain, chData.chainConfig, nil, nil, env, nil, nil)
 			result, _, _ = builder.buildBlock([]types.SimulatedBundle{}, nil, txs)
 		}
 

--- a/miner/algo_test.go
+++ b/miner/algo_test.go
@@ -214,7 +214,6 @@ func BenchmarkAlgo(b *testing.B) {
 				})
 			}
 		}
-
 	}
 }
 

--- a/miner/algo_test.go
+++ b/miner/algo_test.go
@@ -223,11 +223,18 @@ func runAlgoTest(algo AlgoType, config *params.ChainConfig, alloc core.GenesisAl
 	var (
 		statedb, chData = genTestSetupWithAlloc(config, alloc)
 		env             = newEnvironment(chData, statedb, header.Coinbase, header.GasLimit*uint64(scale), header.BaseFee)
-		builder         = newGreedyBuilder(chData.chain, chData.chainConfig, nil, env, nil, nil, algo)
+		resultEnv       *environment
 	)
 
 	// build block
-	resultEnv, _, _ := builder.buildBlock(bundles, nil, txPool)
+	switch algo {
+	case ALGO_GREEDY_BUCKETS:
+		builder := newGreedyBucketsBuilder(chData.chain, chData.chainConfig, nil, env, nil, nil)
+		resultEnv, _, _ = builder.buildBlock(bundles, nil, txPool)
+	case ALGO_GREEDY:
+		builder := newGreedyBucketsBuilder(chData.chain, chData.chainConfig, nil, env, nil, nil)
+		resultEnv, _, _ = builder.buildBlock(bundles, nil, txPool)
+	}
 	return resultEnv.profit, nil
 }
 

--- a/miner/algo_test.go
+++ b/miner/algo_test.go
@@ -229,7 +229,7 @@ func runAlgoTest(algo AlgoType, config *params.ChainConfig, alloc core.GenesisAl
 	// build block
 	switch algo {
 	case ALGO_GREEDY_BUCKETS:
-		builder := newGreedyBucketsBuilder(chData.chain, chData.chainConfig, nil, env, nil, nil)
+		builder := newGreedyBucketsBuilder(chData.chain, chData.chainConfig, nil, nil, env, nil, nil)
 		resultEnv, _, _ = builder.buildBlock(bundles, nil, txPool)
 	case ALGO_GREEDY:
 		builder := newGreedyBuilder(chData.chain, chData.chainConfig, nil, env, nil, nil)

--- a/miner/algo_test.go
+++ b/miner/algo_test.go
@@ -156,6 +156,7 @@ func TestAlgo(t *testing.T) {
 				if err != nil {
 					t.Fatal(err)
 				}
+				t.Logf("Profit: [want: %v] [actual: %v]", gotProfit, test.WantProfit)
 				if test.WantProfit.Cmp(gotProfit) != 0 {
 					t.Fatalf("Profit: want %v, got %v", test.WantProfit, gotProfit)
 				}
@@ -234,6 +235,10 @@ func runAlgoTest(algo AlgoType, config *params.ChainConfig, alloc core.GenesisAl
 	case ALGO_GREEDY:
 		builder := newGreedyBuilder(chData.chain, chData.chainConfig, nil, env, nil, nil)
 		resultEnv, _, _ = builder.buildBlock(bundles, nil, txPool)
+	}
+	fmt.Println("receipt size:", len(resultEnv.receipts))
+	for _, receipt := range resultEnv.receipts {
+		fmt.Println("status: ", receipt.Status)
 	}
 	return resultEnv.profit, nil
 }

--- a/miner/algo_test.go
+++ b/miner/algo_test.go
@@ -232,7 +232,7 @@ func runAlgoTest(algo AlgoType, config *params.ChainConfig, alloc core.GenesisAl
 		builder := newGreedyBucketsBuilder(chData.chain, chData.chainConfig, nil, env, nil, nil)
 		resultEnv, _, _ = builder.buildBlock(bundles, nil, txPool)
 	case ALGO_GREEDY:
-		builder := newGreedyBucketsBuilder(chData.chain, chData.chainConfig, nil, env, nil, nil)
+		builder := newGreedyBuilder(chData.chain, chData.chainConfig, nil, env, nil, nil)
 		resultEnv, _, _ = builder.buildBlock(bundles, nil, txPool)
 	}
 	return resultEnv.profit, nil

--- a/miner/algo_test.go
+++ b/miner/algo_test.go
@@ -156,7 +156,6 @@ func TestAlgo(t *testing.T) {
 				if err != nil {
 					t.Fatal(err)
 				}
-				t.Logf("Profit: [want: %v] [actual: %v]", gotProfit, test.WantProfit)
 				if test.WantProfit.Cmp(gotProfit) != 0 {
 					t.Fatalf("Profit: want %v, got %v", test.WantProfit, gotProfit)
 				}
@@ -235,10 +234,6 @@ func runAlgoTest(algo AlgoType, config *params.ChainConfig, alloc core.GenesisAl
 	case ALGO_GREEDY:
 		builder := newGreedyBuilder(chData.chain, chData.chainConfig, nil, env, nil, nil)
 		resultEnv, _, _ = builder.buildBlock(bundles, nil, txPool)
-	}
-	fmt.Println("receipt size:", len(resultEnv.receipts))
-	for _, receipt := range resultEnv.receipts {
-		fmt.Println("status: ", receipt.Status)
 	}
 	return resultEnv.profit, nil
 }

--- a/miner/algo_test.go
+++ b/miner/algo_test.go
@@ -37,7 +37,8 @@ var algoTests = []*algoTest{
 				},
 			}
 		},
-		WantProfit: big.NewInt(2 * 21_000),
+		WantProfit:          big.NewInt(2 * 21_000),
+		SupportedAlgorithms: []AlgoType{ALGO_GREEDY, ALGO_GREEDY_BUCKETS},
 	},
 	{
 		// Trivial tx pool with 3 txs by two accounts and a block gas limit that only allows two txs
@@ -62,7 +63,8 @@ var algoTests = []*algoTest{
 				},
 			}
 		},
-		WantProfit: big.NewInt(4 * 21_000),
+		WantProfit:          big.NewInt(4 * 21_000),
+		SupportedAlgorithms: []AlgoType{ALGO_GREEDY, ALGO_GREEDY_BUCKETS},
 	},
 	{
 		// Trivial bundle with one tx that reverts but is not allowed to revert.
@@ -79,7 +81,8 @@ var algoTests = []*algoTest{
 				{Txs: types.Transactions{sign(0, &types.LegacyTx{Nonce: 0, Gas: 50_000, To: acc(1), GasPrice: big.NewInt(1)})}},
 			}
 		},
-		WantProfit: big.NewInt(0),
+		WantProfit:          big.NewInt(0),
+		SupportedAlgorithms: []AlgoType{ALGO_GREEDY, ALGO_GREEDY_BUCKETS},
 	},
 	{
 		// Trivial bundle with one tx that reverts and is allowed to revert.
@@ -99,7 +102,8 @@ var algoTests = []*algoTest{
 				},
 			}
 		},
-		WantProfit: big.NewInt(50_000),
+		WantProfit:          big.NewInt(50_000),
+		SupportedAlgorithms: []AlgoType{ALGO_GREEDY, ALGO_GREEDY_BUCKETS},
 	},
 	{
 		// Single failing tx that is included in the tx pool and in a bundle that is not allowed to
@@ -124,7 +128,8 @@ var algoTests = []*algoTest{
 				{Txs: types.Transactions{txs(0, 0)}},
 			}
 		},
-		WantProfit: big.NewInt(50_000),
+		WantProfit:          big.NewInt(50_000),
+		SupportedAlgorithms: []AlgoType{ALGO_GREEDY, ALGO_GREEDY_BUCKETS},
 	},
 }
 
@@ -135,24 +140,27 @@ func TestAlgo(t *testing.T) {
 	)
 
 	for _, test := range algoTests {
-		t.Run(test.Name, func(t *testing.T) {
-			alloc, txPool, bundles, err := test.build(signer, 1)
-			if err != nil {
-				t.Fatalf("Build: %v", err)
-			}
-			simBundles, err := simulateBundles(config, test.Header, alloc, bundles)
-			if err != nil {
-				t.Fatalf("Simulate Bundles: %v", err)
-			}
+		for _, algo := range test.SupportedAlgorithms {
+			testName := fmt.Sprintf("%s-%s", test.Name, algo.String())
+			t.Run(testName, func(t *testing.T) {
+				alloc, txPool, bundles, err := test.build(signer, 1)
+				if err != nil {
+					t.Fatalf("Build: %v", err)
+				}
+				simBundles, err := simulateBundles(config, test.Header, alloc, bundles)
+				if err != nil {
+					t.Fatalf("Simulate Bundles: %v", err)
+				}
 
-			gotProfit, err := runAlgoTest(config, alloc, txPool, simBundles, test.Header, 1)
-			if err != nil {
-				t.Fatal(err)
-			}
-			if test.WantProfit.Cmp(gotProfit) != 0 {
-				t.Fatalf("Profit: want %v, got %v", test.WantProfit, gotProfit)
-			}
-		})
+				gotProfit, err := runAlgoTest(algo, config, alloc, txPool, simBundles, test.Header, 1)
+				if err != nil {
+					t.Fatal(err)
+				}
+				if test.WantProfit.Cmp(gotProfit) != 0 {
+					t.Fatalf("Profit: want %v, got %v", test.WantProfit, gotProfit)
+				}
+			})
+		}
 	}
 }
 
@@ -164,55 +172,59 @@ func BenchmarkAlgo(b *testing.B) {
 	)
 
 	for _, test := range algoTests {
-		for _, scale := range scales {
-			wantScaledProfit := new(big.Int).Mul(
-				big.NewInt(int64(scale)),
-				test.WantProfit,
-			)
+		for _, algo := range test.SupportedAlgorithms {
+			for _, scale := range scales {
+				wantScaledProfit := new(big.Int).Mul(
+					big.NewInt(int64(scale)),
+					test.WantProfit,
+				)
 
-			b.Run(fmt.Sprintf("%s_%d", test.Name, scale), func(b *testing.B) {
-				alloc, txPool, bundles, err := test.build(signer, scale)
-				if err != nil {
-					b.Fatalf("Build: %v", err)
-				}
-				simBundles, err := simulateBundles(config, test.Header, alloc, bundles)
-				if err != nil {
-					b.Fatalf("Simulate Bundles: %v", err)
-				}
-
-				b.ResetTimer()
-				var txPoolCopy map[common.Address]types.Transactions
-				for i := 0; i < b.N; i++ {
-					// Note: copy is needed as the greedyAlgo modifies the txPool.
-					func() {
-						b.StopTimer()
-						defer b.StartTimer()
-
-						txPoolCopy = make(map[common.Address]types.Transactions, len(txPool))
-						for addr, txs := range txPool {
-							txPoolCopy[addr] = txs
-						}
-					}()
-
-					gotProfit, err := runAlgoTest(config, alloc, txPoolCopy, simBundles, test.Header, scale)
+				b.Run(fmt.Sprintf("%s-%s-%d", test.Name, algo.String(), scale), func(b *testing.B) {
+					alloc, txPool, bundles, err := test.build(signer, scale)
 					if err != nil {
-						b.Fatal(err)
+						b.Fatalf("Build: %v", err)
 					}
-					if wantScaledProfit.Cmp(gotProfit) != 0 {
-						b.Fatalf("Profit: want %v, got %v", wantScaledProfit, gotProfit)
+					simBundles, err := simulateBundles(config, test.Header, alloc, bundles)
+					if err != nil {
+						b.Fatalf("Simulate Bundles: %v", err)
 					}
-				}
-			})
+
+					b.ResetTimer()
+					var txPoolCopy map[common.Address]types.Transactions
+					for i := 0; i < b.N; i++ {
+						// Note: copy is needed as the greedyAlgo modifies the txPool.
+						func() {
+							b.StopTimer()
+							defer b.StartTimer()
+
+							txPoolCopy = make(map[common.Address]types.Transactions, len(txPool))
+							for addr, txs := range txPool {
+								txPoolCopy[addr] = txs
+							}
+						}()
+
+						gotProfit, err := runAlgoTest(algo, config, alloc, txPoolCopy, simBundles, test.Header, scale)
+						if err != nil {
+							b.Fatal(err)
+						}
+						if wantScaledProfit.Cmp(gotProfit) != 0 {
+							b.Fatalf("Profit: want %v, got %v", wantScaledProfit, gotProfit)
+						}
+					}
+				})
+			}
 		}
+
 	}
 }
 
 // runAlgo executes a single algoTest case and returns the profit.
-func runAlgoTest(config *params.ChainConfig, alloc core.GenesisAlloc, txPool map[common.Address]types.Transactions, bundles []types.SimulatedBundle, header *types.Header, scale int) (gotProfit *big.Int, err error) {
+func runAlgoTest(algo AlgoType, config *params.ChainConfig, alloc core.GenesisAlloc,
+	txPool map[common.Address]types.Transactions, bundles []types.SimulatedBundle, header *types.Header, scale int) (gotProfit *big.Int, err error) {
 	var (
 		statedb, chData = genTestSetupWithAlloc(config, alloc)
 		env             = newEnvironment(chData, statedb, header.Coinbase, header.GasLimit*uint64(scale), header.BaseFee)
-		builder         = newGreedyBuilder(chData.chain, chData.chainConfig, nil, env, nil, nil)
+		builder         = newGreedyBuilder(chData.chain, chData.chainConfig, nil, env, nil, nil, algo)
 	)
 
 	// build block
@@ -260,6 +272,8 @@ type algoTest struct {
 	Bundles func(accByIndex, signByIndex, txByAccIndexAndNonce) []*bundle
 
 	WantProfit *big.Int // Expected block profit
+
+	SupportedAlgorithms []AlgoType
 }
 
 // setDefaults sets default values for the algoTest.

--- a/miner/miner.go
+++ b/miner/miner.go
@@ -51,7 +51,8 @@ type Backend interface {
 type AlgoType int
 
 const (
-	ALGO_MEV_GETH AlgoType = iota
+	ALGO_INVALID AlgoType = iota
+	ALGO_MEV_GETH
 	ALGO_GREEDY
 )
 
@@ -62,7 +63,7 @@ func AlgoTypeFlagToEnum(algoString string) (AlgoType, error) {
 	case "greedy":
 		return ALGO_GREEDY, nil
 	default:
-		return ALGO_MEV_GETH, errors.New("algo not recognized")
+		return ALGO_INVALID, errors.New("algo not recognized")
 	}
 }
 

--- a/miner/miner.go
+++ b/miner/miner.go
@@ -51,8 +51,7 @@ type Backend interface {
 type AlgoType int
 
 const (
-	ALGO_INVALID AlgoType = iota
-	ALGO_MEV_GETH
+	ALGO_MEV_GETH AlgoType = iota
 	ALGO_GREEDY
 )
 
@@ -63,7 +62,7 @@ func AlgoTypeFlagToEnum(algoString string) (AlgoType, error) {
 	case "greedy":
 		return ALGO_GREEDY, nil
 	default:
-		return ALGO_INVALID, errors.New("algo not recognized")
+		return ALGO_MEV_GETH, errors.New("algo not recognized")
 	}
 }
 

--- a/miner/miner.go
+++ b/miner/miner.go
@@ -53,13 +53,29 @@ type AlgoType int
 const (
 	ALGO_MEV_GETH AlgoType = iota
 	ALGO_GREEDY
+	ALGO_GREEDY_BUCKETS
 )
 
+func (a AlgoType) String() string {
+	switch a {
+	case ALGO_GREEDY:
+		return "greedy"
+	case ALGO_MEV_GETH:
+		return "mev-geth"
+	case ALGO_GREEDY_BUCKETS:
+		return "greedy-buckets"
+	default:
+		return "unsupported"
+	}
+}
+
 func AlgoTypeFlagToEnum(algoString string) (AlgoType, error) {
-	switch algoString {
-	case "mev-geth":
+	switch strings.ToLower(algoString) {
+	case ALGO_MEV_GETH.String():
 		return ALGO_MEV_GETH, nil
-	case "greedy":
+	case ALGO_GREEDY_BUCKETS.String():
+		return ALGO_GREEDY_BUCKETS, nil
+	case ALGO_GREEDY.String():
 		return ALGO_GREEDY, nil
 	default:
 		return ALGO_MEV_GETH, errors.New("algo not recognized")

--- a/miner/miner.go
+++ b/miner/miner.go
@@ -54,7 +54,6 @@ const (
 	ALGO_MEV_GETH AlgoType = iota
 	ALGO_GREEDY
 	ALGO_GREEDY_BUCKETS
-	ALGO_TEST_ONLY
 )
 
 func (a AlgoType) String() string {
@@ -65,8 +64,6 @@ func (a AlgoType) String() string {
 		return "mev-geth"
 	case ALGO_GREEDY_BUCKETS:
 		return "greedy-buckets"
-	case ALGO_TEST_ONLY:
-		return "test-only"
 	default:
 		return "unsupported"
 	}
@@ -80,8 +77,6 @@ func AlgoTypeFlagToEnum(algoString string) (AlgoType, error) {
 		return ALGO_GREEDY_BUCKETS, nil
 	case ALGO_GREEDY.String():
 		return ALGO_GREEDY, nil
-	case ALGO_TEST_ONLY.String():
-		return ALGO_TEST_ONLY, nil
 	default:
 		return ALGO_MEV_GETH, errors.New("algo not recognized")
 	}

--- a/miner/miner.go
+++ b/miner/miner.go
@@ -54,6 +54,7 @@ const (
 	ALGO_MEV_GETH AlgoType = iota
 	ALGO_GREEDY
 	ALGO_GREEDY_BUCKETS
+	ALGO_TEST_ONLY
 )
 
 func (a AlgoType) String() string {
@@ -64,6 +65,8 @@ func (a AlgoType) String() string {
 		return "mev-geth"
 	case ALGO_GREEDY_BUCKETS:
 		return "greedy-buckets"
+	case ALGO_TEST_ONLY:
+		return "test-only"
 	default:
 		return "unsupported"
 	}
@@ -77,6 +80,8 @@ func AlgoTypeFlagToEnum(algoString string) (AlgoType, error) {
 		return ALGO_GREEDY_BUCKETS, nil
 	case ALGO_GREEDY.String():
 		return ALGO_GREEDY, nil
+	case ALGO_TEST_ONLY.String():
+		return ALGO_TEST_ONLY, nil
 	default:
 		return ALGO_MEV_GETH, errors.New("algo not recognized")
 	}

--- a/miner/multi_worker.go
+++ b/miner/multi_worker.go
@@ -138,10 +138,13 @@ func (w *multiWorker) buildPayload(args *BuildPayloadArgs) (*Payload, error) {
 }
 
 func newMultiWorker(config *Config, chainConfig *params.ChainConfig, engine consensus.Engine, eth Backend, mux *event.TypeMux, isLocalBlock func(header *types.Header) bool, init bool) *multiWorker {
-	if config.AlgoType != ALGO_MEV_GETH {
-		return newMultiWorkerGreedy(config, chainConfig, engine, eth, mux, isLocalBlock, init)
-	} else {
+	switch config.AlgoType {
+	case ALGO_MEV_GETH:
 		return newMultiWorkerMevGeth(config, chainConfig, engine, eth, mux, isLocalBlock, init)
+	case ALGO_GREEDY, ALGO_GREEDY_BUCKETS:
+		return newMultiWorkerGreedy(config, chainConfig, engine, eth, mux, isLocalBlock, init)
+	default:
+		panic("unsupported builder algorithm found")
 	}
 }
 

--- a/miner/multi_worker.go
+++ b/miner/multi_worker.go
@@ -141,7 +141,7 @@ func newMultiWorker(config *Config, chainConfig *params.ChainConfig, engine cons
 	switch config.AlgoType {
 	case ALGO_MEV_GETH:
 		return newMultiWorkerMevGeth(config, chainConfig, engine, eth, mux, isLocalBlock, init)
-	case ALGO_GREEDY, ALGO_GREEDY_BUCKETS:
+	case ALGO_GREEDY, ALGO_GREEDY_BUCKETS, ALGO_TEST_ONLY:
 		return newMultiWorkerGreedy(config, chainConfig, engine, eth, mux, isLocalBlock, init)
 	default:
 		panic("unsupported builder algorithm found")

--- a/miner/multi_worker.go
+++ b/miner/multi_worker.go
@@ -141,7 +141,7 @@ func newMultiWorker(config *Config, chainConfig *params.ChainConfig, engine cons
 	switch config.AlgoType {
 	case ALGO_MEV_GETH:
 		return newMultiWorkerMevGeth(config, chainConfig, engine, eth, mux, isLocalBlock, init)
-	case ALGO_GREEDY, ALGO_GREEDY_BUCKETS, ALGO_TEST_ONLY:
+	case ALGO_GREEDY, ALGO_GREEDY_BUCKETS:
 		return newMultiWorkerGreedy(config, chainConfig, engine, eth, mux, isLocalBlock, init)
 	default:
 		panic("unsupported builder algorithm found")

--- a/miner/sbundle_test.go
+++ b/miner/sbundle_test.go
@@ -480,7 +480,7 @@ func TestSBundles(t *testing.T) {
 				MevGasPrice: big.NewInt(1),
 				Profit:      big.NewInt(1),
 			}
-			err = envDiff.commitSBundle(&sim, chData, nil, builderPrivKey, false)
+			err = envDiff.commitSBundle(&sim, chData, nil, builderPrivKey, defaultValidationConfig)
 			if tt.ShouldFail {
 				require.Error(t, err)
 			} else {

--- a/miner/sbundle_test.go
+++ b/miner/sbundle_test.go
@@ -480,7 +480,7 @@ func TestSBundles(t *testing.T) {
 				MevGasPrice: big.NewInt(1),
 				Profit:      big.NewInt(1),
 			}
-			err = envDiff.commitSBundle(&sim, chData, nil, builderPrivKey)
+			err = envDiff.commitSBundle(&sim, chData, nil, builderPrivKey, false)
 			if tt.ShouldFail {
 				require.Error(t, err)
 			} else {

--- a/miner/sbundle_test.go
+++ b/miner/sbundle_test.go
@@ -480,7 +480,7 @@ func TestSBundles(t *testing.T) {
 				MevGasPrice: big.NewInt(1),
 				Profit:      big.NewInt(1),
 			}
-			err = envDiff.commitSBundle(&sim, chData, nil, builderPrivKey, defaultValidationConfig)
+			err = envDiff.commitSBundle(&sim, chData, nil, builderPrivKey, defaultAlgorithmConfig)
 			if tt.ShouldFail {
 				require.Error(t, err)
 			} else {

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -1311,7 +1311,7 @@ func (w *worker) fillTransactionsSelectAlgo(interrupt *int32, env *environment) 
 		err          error
 	)
 	switch w.flashbots.algoType {
-	case ALGO_GREEDY, ALGO_GREEDY_BUCKETS, ALGO_TEST_ONLY:
+	case ALGO_GREEDY, ALGO_GREEDY_BUCKETS:
 		blockBundles, allBundles, usedSbundles, err = w.fillTransactionsAlgoWorker(interrupt, env)
 	case ALGO_MEV_GETH:
 		blockBundles, allBundles, err = w.fillTransactions(interrupt, env)
@@ -1404,99 +1404,6 @@ func (w *worker) fillTransactionsAlgoWorker(interrupt *int32, env *environment) 
 	start := time.Now()
 
 	switch w.flashbots.algoType {
-	case ALGO_TEST_ONLY:
-		var (
-			algorithms      = []AlgoType{ALGO_GREEDY, ALGO_GREEDY_BUCKETS, ALGO_GREEDY_BUCKETS}
-			validationConfs = []*algorithmConfig{
-				&defaultAlgorithmConfig,
-				{
-					EnforceProfit:          true,
-					ExpectedProfit:         nil,
-					ProfitThresholdPercent: common.Big0, // 0% emulates naive total profit algorithm using greedy buckets
-				},
-				{
-					EnforceProfit:          true,
-					ExpectedProfit:         nil,
-					ProfitThresholdPercent: defaultProfitThreshold,
-				},
-			}
-			environments = make([]*environment, len(algorithms))
-
-			pendingTxs = make([]map[common.Address]types.Transactions, len(algorithms))
-
-			results = make([]struct {
-				validationConf algorithmConfig
-				duration       time.Duration
-				profit         *big.Int
-				simBundles     []types.SimulatedBundle
-				usedSbundle    []types.UsedSBundle
-				environment    *environment
-			}, len(algorithms))
-		)
-
-		for i := range environments {
-			environments[i] = env.copy()
-		}
-
-		for i := range pendingTxs {
-			pendingTxs[i] = make(map[common.Address]types.Transactions, len(pending))
-			for acc, txs := range pending {
-				p := make(types.Transactions, len(txs))
-				copy(p, txs)
-				pendingTxs[i][acc] = p
-			}
-		}
-
-		var (
-			wg    sync.WaitGroup
-			start = time.Now()
-		)
-		wg.Add(len(algorithms))
-		for i, algo := range algorithms {
-			go func(i int, algo AlgoType) {
-				defer wg.Done()
-
-				switch algo {
-				case ALGO_GREEDY:
-					builder := newGreedyBuilder(w.chain, w.chainConfig, w.blockList, environments[i], w.config.BuilderTxSigningKey, interrupt)
-					newEnv, blockBundles, usedSbundle = builder.buildBlock(bundlesToConsider, sbundlesToConsider, pendingTxs[i])
-				case ALGO_GREEDY_BUCKETS:
-					validationConf := validationConfs[i]
-					builder := newGreedyBucketsBuilder(w.chain, w.chainConfig, validationConf, w.blockList, environments[i],
-						w.config.BuilderTxSigningKey, interrupt)
-					newEnv, blockBundles, usedSbundle = builder.buildBlock(bundlesToConsider, sbundlesToConsider, pendingTxs[i])
-				}
-				results[i] = struct {
-					validationConf algorithmConfig
-					duration       time.Duration
-					profit         *big.Int
-					simBundles     []types.SimulatedBundle
-					usedSbundle    []types.UsedSBundle
-					environment    *environment
-				}{
-					validationConf: *validationConfs[i],
-					duration:       time.Since(start),
-					profit:         new(big.Int).Sub(newEnv.profit, environments[i].profit),
-					simBundles:     blockBundles,
-					usedSbundle:    usedSbundle,
-					environment:    environments[i],
-				}
-			}(i, algo)
-		}
-		wg.Wait()
-
-		for i := range results {
-			log.Info("[test-algo] block build complete",
-				"algo", algorithms[i].String(),
-				"duration", results[i].duration.Nanoseconds(),
-				"profit", results[i].profit.String(),
-				"num-txs", len(results[i].environment.txs),
-				"profit-threshold", results[i].validationConf.ProfitThresholdPercent.String(),
-				"num-bundles", len(results[i].simBundles),
-				"num-usedSbundles", len(results[i].usedSbundle),
-			)
-		}
-
 	case ALGO_GREEDY_BUCKETS:
 		validationConf := &algorithmConfig{
 			EnforceProfit:          true,

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -1407,8 +1407,8 @@ func (w *worker) fillTransactionsAlgoWorker(interrupt *int32, env *environment) 
 	case ALGO_TEST_ONLY:
 		var (
 			algorithms      = []AlgoType{ALGO_GREEDY, ALGO_GREEDY_BUCKETS, ALGO_GREEDY_BUCKETS}
-			validationConfs = []*validationConfig{
-				&defaultValidationConfig,
+			validationConfs = []*algorithmConfig{
+				&defaultAlgorithmConfig,
 				{
 					EnforceProfit:          true,
 					ExpectedProfit:         nil,
@@ -1425,7 +1425,7 @@ func (w *worker) fillTransactionsAlgoWorker(interrupt *int32, env *environment) 
 			pendingTxs = make([]map[common.Address]types.Transactions, len(algorithms))
 
 			results = make([]struct {
-				validationConf validationConfig
+				validationConf algorithmConfig
 				duration       time.Duration
 				profit         *big.Int
 				simBundles     []types.SimulatedBundle
@@ -1467,7 +1467,7 @@ func (w *worker) fillTransactionsAlgoWorker(interrupt *int32, env *environment) 
 					newEnv, blockBundles, usedSbundle = builder.buildBlock(bundlesToConsider, sbundlesToConsider, pendingTxs[i])
 				}
 				results[i] = struct {
-					validationConf validationConfig
+					validationConf algorithmConfig
 					duration       time.Duration
 					profit         *big.Int
 					simBundles     []types.SimulatedBundle
@@ -1498,7 +1498,7 @@ func (w *worker) fillTransactionsAlgoWorker(interrupt *int32, env *environment) 
 		}
 
 	case ALGO_GREEDY_BUCKETS:
-		validationConf := &validationConfig{
+		validationConf := &algorithmConfig{
 			EnforceProfit:          true,
 			ExpectedProfit:         nil,
 			ProfitThresholdPercent: defaultProfitThreshold,

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -1303,7 +1303,7 @@ func (w *worker) prepareWork(genParams *generateParams) (*environment, error) {
 	return env, nil
 }
 
-func (w *worker) fillTransactionsSelectAlgo(interrupt *int32, env *environment) (error, []types.SimulatedBundle, []types.SimulatedBundle, []types.UsedSBundle) {
+func (w *worker) fillTransactionsSelectAlgo(interrupt *int32, env *environment) ([]types.SimulatedBundle, []types.SimulatedBundle, []types.UsedSBundle, error) {
 	var (
 		blockBundles []types.SimulatedBundle
 		allBundles   []types.SimulatedBundle
@@ -1312,20 +1312,20 @@ func (w *worker) fillTransactionsSelectAlgo(interrupt *int32, env *environment) 
 	)
 	switch w.flashbots.algoType {
 	case ALGO_GREEDY:
-		err, blockBundles, allBundles, usedSbundles = w.fillTransactionsAlgoWorker(interrupt, env)
+		blockBundles, allBundles, usedSbundles, err = w.fillTransactionsAlgoWorker(interrupt, env)
 	case ALGO_MEV_GETH:
-		err, blockBundles, allBundles = w.fillTransactions(interrupt, env)
+		blockBundles, allBundles, err = w.fillTransactions(interrupt, env)
 	default:
-		err, blockBundles, allBundles = w.fillTransactions(interrupt, env)
+		blockBundles, allBundles, err = w.fillTransactions(interrupt, env)
 	}
-	return err, blockBundles, allBundles, usedSbundles
+	return blockBundles, allBundles, usedSbundles, err
 }
 
 // fillTransactions retrieves the pending transactions from the txpool and fills them
 // into the given sealing block. The transaction selection and ordering strategy can
 // be customized with the plugin in the future.
 // Returns error if any, otherwise the bundles that made it into the block and all bundles that passed simulation
-func (w *worker) fillTransactions(interrupt *int32, env *environment) (error, []types.SimulatedBundle, []types.SimulatedBundle) {
+func (w *worker) fillTransactions(interrupt *int32, env *environment) ([]types.SimulatedBundle, []types.SimulatedBundle, error) {
 	// Split the pending transactions into locals and remotes
 	// Fill the block with all available pending transactions.
 	pending := w.eth.TxPool().Pending(true)
@@ -1343,23 +1343,25 @@ func (w *worker) fillTransactions(interrupt *int32, env *environment) (error, []
 		bundles, ccBundleCh := w.eth.TxPool().MevBundles(env.header.Number, env.header.Time)
 		bundles = append(bundles, <-ccBundleCh...)
 
-		var bundleTxs types.Transactions
-		var resultingBundle simulatedBundle
-		var mergedBundles []types.SimulatedBundle
-		var numBundles int
-		var err error
+		var (
+			bundleTxs       types.Transactions
+			resultingBundle simulatedBundle
+			mergedBundles   []types.SimulatedBundle
+			numBundles      int
+			err             error
+		)
 		// Sets allBundles in outer scope
 		bundleTxs, resultingBundle, mergedBundles, numBundles, allBundles, err = w.generateFlashbotsBundle(env, bundles, pending)
 		if err != nil {
 			log.Error("Failed to generate flashbots bundle", "err", err)
-			return err, nil, nil
+			return nil, nil, err
 		}
 		log.Info("Flashbots bundle", "ethToCoinbase", ethIntToFloat(resultingBundle.TotalEth), "gasUsed", resultingBundle.TotalGasUsed, "bundleScore", resultingBundle.MevGasPrice, "bundleLength", len(bundleTxs), "numBundles", numBundles, "worker", w.flashbots.maxMergedBundles)
 		if len(bundleTxs) == 0 {
-			return errors.New("no bundles to apply"), nil, nil
+			return nil, nil, errors.New("no bundles to apply")
 		}
 		if err := w.commitBundle(env, bundleTxs, interrupt); err != nil {
-			return err, nil, nil
+			return nil, nil, err
 		}
 		blockBundles = mergedBundles
 		env.profit.Add(env.profit, resultingBundle.EthSentToCoinbase)
@@ -1368,29 +1370,29 @@ func (w *worker) fillTransactions(interrupt *int32, env *environment) (error, []
 	if len(localTxs) > 0 {
 		txs := types.NewTransactionsByPriceAndNonce(env.signer, localTxs, nil, nil, env.header.BaseFee)
 		if err := w.commitTransactions(env, txs, interrupt); err != nil {
-			return err, nil, nil
+			return nil, nil, err
 		}
 	}
 	if len(remoteTxs) > 0 {
 		txs := types.NewTransactionsByPriceAndNonce(env.signer, remoteTxs, nil, nil, env.header.BaseFee)
 		if err := w.commitTransactions(env, txs, interrupt); err != nil {
-			return err, nil, nil
+			return nil, nil, err
 		}
 	}
 
-	return nil, blockBundles, allBundles
+	return blockBundles, allBundles, nil
 }
 
 // fillTransactionsAlgoWorker retrieves the pending transactions and bundles from the txpool and fills them
 // into the given sealing block.
 // Returns error if any, otherwise the bundles that made it into the block and all bundles that passed simulation
-func (w *worker) fillTransactionsAlgoWorker(interrupt *int32, env *environment) (error, []types.SimulatedBundle, []types.SimulatedBundle, []types.UsedSBundle) {
+func (w *worker) fillTransactionsAlgoWorker(interrupt *int32, env *environment) ([]types.SimulatedBundle, []types.SimulatedBundle, []types.UsedSBundle, error) {
 	// Split the pending transactions into locals and remotes
 	// Fill the block with all available pending transactions.
 	pending := w.eth.TxPool().Pending(true)
 	bundlesToConsider, sbundlesToConsider, err := w.getSimulatedBundles(env)
 	if err != nil {
-		return err, nil, nil, nil
+		return nil, nil, nil, err
 	}
 
 	builder := newGreedyBuilder(w.chain, w.chainConfig, w.blockList, env, w.config.BuilderTxSigningKey, interrupt)
@@ -1401,7 +1403,7 @@ func (w *worker) fillTransactionsAlgoWorker(interrupt *int32, env *environment) 
 	}
 	*env = *newEnv
 
-	return nil, blockBundles, bundlesToConsider, usedSbundle
+	return blockBundles, bundlesToConsider, usedSbundle, err
 }
 
 func (w *worker) getSimulatedBundles(env *environment) ([]types.SimulatedBundle, []*types.SimSBundle, error) {
@@ -1491,7 +1493,7 @@ func (w *worker) generateWork(params *generateParams) (*types.Block, *big.Int, e
 
 	orderCloseTime := time.Now()
 
-	err, blockBundles, allBundles, usedSbundles := w.fillTransactionsSelectAlgo(nil, work)
+	blockBundles, allBundles, usedSbundles, err := w.fillTransactionsSelectAlgo(nil, work)
 
 	if err != nil {
 		return nil, nil, err
@@ -1582,7 +1584,7 @@ func (w *worker) commitWork(interrupt *int32, noempty bool, timestamp int64) {
 	}
 
 	// Fill pending transactions from the txpool
-	err, _, _, _ = w.fillTransactionsSelectAlgo(interrupt, work)
+	_, _, _, err = w.fillTransactionsSelectAlgo(interrupt, work)
 	switch {
 	case err == nil:
 		// The entire block is filled, decrease resubmit interval in case

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -1311,7 +1311,7 @@ func (w *worker) fillTransactionsSelectAlgo(interrupt *int32, env *environment) 
 		err          error
 	)
 	switch w.flashbots.algoType {
-	case ALGO_GREEDY:
+	case ALGO_GREEDY, ALGO_GREEDY_BUCKETS:
 		blockBundles, allBundles, usedSbundles, err = w.fillTransactionsAlgoWorker(interrupt, env)
 	case ALGO_MEV_GETH:
 		blockBundles, allBundles, err = w.fillTransactions(interrupt, env)
@@ -1395,7 +1395,11 @@ func (w *worker) fillTransactionsAlgoWorker(interrupt *int32, env *environment) 
 		return nil, nil, nil, err
 	}
 
-	builder := newGreedyBuilder(w.chain, w.chainConfig, w.blockList, env, w.config.BuilderTxSigningKey, interrupt)
+	builder := newGreedyBuilder(
+		w.chain, w.chainConfig, w.blockList, env,
+		w.config.BuilderTxSigningKey, interrupt, w.flashbots.algoType,
+	)
+
 	start := time.Now()
 	newEnv, blockBundles, usedSbundle := builder.buildBlock(bundlesToConsider, sbundlesToConsider, pending)
 	if metrics.EnabledBuilder {


### PR DESCRIPTION
## 📝 Summary

- This PR adds support for a new block building algorithm type, called `greedy-buckets` 
- The new algorithm attempts to insert transactions by both effective gas price and profit. This is in contrast to the `greedy` algorithm which simply uses effective gas price 


## Testing
- Tested locally and on production mainnet
- Observed a healthy number of higher bids with the new algorithm, screenshot below compares how often the new algorithm in blue outbid the existing one in orange: 
<img width="1533" alt="image" src="https://github.com/flashbots/builder/assets/3589723/62118f8a-53f8-42c3-986a-b6598a712ba9">

- Below is a chart that compares top bid of each algorithm per block building attempt
![image](https://github.com/flashbots/builder/assets/3589723/5751d5b9-3759-4a82-97de-9ff684cd80a3)

## 📚 References

- [The Knapsack Problem with Conflict Graphs](https://jgaa.info/accepted/2009/PferschySchauer2009.13.2.pdf)

---

* [x] I have seen and agree to [`CONTRIBUTING.md`](https://github.com/flashbots/builder/blob/main/CONTRIBUTING.md)
