### PR TITLE
Use access list tracing in builder

### DIFF
--- a/miner/algo_common.go
+++ b/miner/algo_common.go
@@ -111,13 +111,15 @@ func applyTransactionWithBlacklist(signer types.Signer, config *params.ChainConf
 		}
 	}
 
-	touchTracer := logger.NewAccountTouchTracer()
+	// we set precompile to nil, but they are set in the validation code
+	// there will be no difference in the result if precompile is not it the blocklist
+	touchTracer := logger.NewAccessListTracer(nil, common.Address{}, common.Address{}, nil)
 	cfg.Tracer = touchTracer
 	cfg.Debug = true
 
 	hook := func() error {
-		for _, address := range touchTracer.TouchedAddresses() {
-			if _, in := blacklist[address]; in {
+		for _, accessTuple := range touchTracer.AccessList() {
+			if _, in := blacklist[accessTuple.Address]; in {
 				return errors.New("blacklist violation, tx trace")
 			}
 		}

--- a/miner/algo_common_test.go
+++ b/miner/algo_common_test.go
@@ -472,10 +472,20 @@ func TestBlacklist(t *testing.T) {
 
 	tx = signers.signTx(4, 40000, big.NewInt(0), big.NewInt(1), payProxyAddress, big.NewInt(99), calldata)
 	_, _, err = envDiff.commitTx(tx, chData)
-	fmt.Println("balance", envDiff.state.GetBalance(signers.addresses[3]))
-
 	if err == nil {
 		t.Fatal("committed blacklisted transaction: trace")
+	}
+
+	tx = signers.signTx(5, 40000, big.NewInt(0), big.NewInt(1), payProxyAddress, big.NewInt(0), calldata)
+	_, _, err = envDiff.commitTx(tx, chData)
+	if err == nil {
+		t.Fatal("committed blacklisted transaction: trace, zero value")
+	}
+
+	tx = signers.signTx(6, 30000, big.NewInt(0), big.NewInt(1), payProxyAddress, big.NewInt(99), calldata)
+	_, _, err = envDiff.commitTx(tx, chData)
+	if err == nil {
+		t.Fatal("committed blacklisted transaction: trace, failed tx")
 	}
 
 	if *envDiff.gasPool != gasPoolBefore {


### PR DESCRIPTION
## 📝 Summary

<!--- A general summary of your changes -->

Before our builder would use tracer where internal calls to the blocklisted addresses with insufficient balance for value or intrinsic gas would go through. 

## 📚 References

<!-- Any interesting external links to documentation, articles, tweets which add value to the PR -->

---

* [x] I have seen and agree to [`CONTRIBUTING.md`](https://github.com/flashbots/builder/blob/main/CONTRIBUTING.md)
