### PR TITLE
[trivial] Add builder submission offset from end of slot flag and set default to 3 seconds from end of slot  

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,10 +48,10 @@ $ geth --help
     --builder.block_resubmit_interval value (default: "500ms")
           Determines the interval at which builder will resubmit block submissions
           [$FLASHBOTS_BUILDER_RATE_LIMIT_RESUBMIT_INTERVAL]
-   
+
     --builder.cancellations        (default: false)
           Enable cancellations for the builder
-   
+
     --builder.dry-run              (default: false)
           Builder only validates blocks without submission to the relay
 
@@ -75,15 +75,16 @@ $ geth --help
           Disable the bundle fetcher
 
     --builder.rate_limit_duration value (default: "500ms")
-          Determines rate limit of events processed by builder; a duration string is a
-          possibly signed sequence of decimal numbers, each with optional fraction and a
-          unit suffix, such as "300ms", "-1.5h" or "2h45m"
+          Determines rate limit of events processed by builder. For example, a value of
+          "500ms" denotes that the builder processes events every 500ms. A duration string
+          is a possibly signed sequence of decimal numbers, each with optional fraction
+          and a unit suffix, such as "300ms", "-1.5h" or "2h45m"
           [$FLASHBOTS_BUILDER_RATE_LIMIT_DURATION]
-   
+
     --builder.rate_limit_max_burst value (default: 10)
           Determines the maximum number of burst events the builder can accommodate at any
           given point in time. [$FLASHBOTS_BUILDER_RATE_LIMIT_MAX_BURST]
-   
+
     --builder.relay_secret_key value (default: "0x2fc12ae741f29701f8e30f5de6350766c020cb80768a0ff01e6838ffd2431e11")
           Builder local relay API key used for signing headers [$BUILDER_RELAY_SECRET_KEY]
 
@@ -104,6 +105,12 @@ $ geth --help
 
     --builder.slots_in_epoch value (default: 32)
           Set the number of slots in an epoch in the local relay
+
+    --builder.submission_offset value (default: 3s)
+          Determines the offset from the end of slot time that the builder will submit
+          blocks. For example, if a slot is 12 seconds long, and the offset is 2 seconds,
+          the builder will submit blocks at 10 seconds into the slot.
+          [$FLASHBOTS_BUILDER_SUBMISSION_OFFSET]
 
     --builder.validation_blacklist value
           Path to file containing blacklisted addresses, json-encoded list of strings

--- a/builder/config.go
+++ b/builder/config.go
@@ -1,28 +1,31 @@
 package builder
 
+import "time"
+
 type Config struct {
-	Enabled                          bool     `toml:",omitempty"`
-	EnableValidatorChecks            bool     `toml:",omitempty"`
-	EnableLocalRelay                 bool     `toml:",omitempty"`
-	SlotsInEpoch                     uint64   `toml:",omitempty"`
-	SecondsInSlot                    uint64   `toml:",omitempty"`
-	DisableBundleFetcher             bool     `toml:",omitempty"`
-	DryRun                           bool     `toml:",omitempty"`
-	IgnoreLatePayloadAttributes      bool     `toml:",omitempty"`
-	BuilderSecretKey                 string   `toml:",omitempty"`
-	RelaySecretKey                   string   `toml:",omitempty"`
-	ListenAddr                       string   `toml:",omitempty"`
-	GenesisForkVersion               string   `toml:",omitempty"`
-	BellatrixForkVersion             string   `toml:",omitempty"`
-	GenesisValidatorsRoot            string   `toml:",omitempty"`
-	BeaconEndpoints                  []string `toml:",omitempty"`
-	RemoteRelayEndpoint              string   `toml:",omitempty"`
-	SecondaryRemoteRelayEndpoints    []string `toml:",omitempty"`
-	ValidationBlocklist              string   `toml:",omitempty"`
-	BuilderRateLimitDuration         string   `toml:",omitempty"`
-	BuilderRateLimitMaxBurst         int      `toml:",omitempty"`
-	BuilderRateLimitResubmitInterval string   `toml:",omitempty"`
-	EnableCancellations              bool     `toml:",omitempty"`
+	Enabled                          bool          `toml:",omitempty"`
+	EnableValidatorChecks            bool          `toml:",omitempty"`
+	EnableLocalRelay                 bool          `toml:",omitempty"`
+	SlotsInEpoch                     uint64        `toml:",omitempty"`
+	SecondsInSlot                    uint64        `toml:",omitempty"`
+	DisableBundleFetcher             bool          `toml:",omitempty"`
+	DryRun                           bool          `toml:",omitempty"`
+	IgnoreLatePayloadAttributes      bool          `toml:",omitempty"`
+	BuilderSecretKey                 string        `toml:",omitempty"`
+	RelaySecretKey                   string        `toml:",omitempty"`
+	ListenAddr                       string        `toml:",omitempty"`
+	GenesisForkVersion               string        `toml:",omitempty"`
+	BellatrixForkVersion             string        `toml:",omitempty"`
+	GenesisValidatorsRoot            string        `toml:",omitempty"`
+	BeaconEndpoints                  []string      `toml:",omitempty"`
+	RemoteRelayEndpoint              string        `toml:",omitempty"`
+	SecondaryRemoteRelayEndpoints    []string      `toml:",omitempty"`
+	ValidationBlocklist              string        `toml:",omitempty"`
+	BuilderRateLimitDuration         string        `toml:",omitempty"`
+	BuilderRateLimitMaxBurst         int           `toml:",omitempty"`
+	BuilderRateLimitResubmitInterval string        `toml:",omitempty"`
+	BuilderSubmissionOffset          time.Duration `toml:",omitempty"`
+	EnableCancellations              bool          `toml:",omitempty"`
 }
 
 // DefaultConfig is the default config for the builder.

--- a/cmd/geth/main.go
+++ b/cmd/geth/main.go
@@ -178,6 +178,7 @@ var (
 		utils.BuilderRateLimitDuration,
 		utils.BuilderRateLimitMaxBurst,
 		utils.BuilderBlockResubmitInterval,
+		utils.BuilderSubmissionOffset,
 		utils.BuilderEnableCancellations,
 	}
 

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -809,7 +809,8 @@ var (
 
 	BuilderRateLimitDuration = &cli.StringFlag{
 		Name: "builder.rate_limit_duration",
-		Usage: "Determines rate limit of events processed by builder; a duration string is a possibly signed sequence " +
+		Usage: "Determines rate limit of events processed by builder. For example, a value of \"500ms\" denotes that the builder processes events every 500ms. " +
+			"A duration string is a possibly signed sequence " +
 			"of decimal numbers, each with optional fraction and a unit suffix, such as \"300ms\", \"-1.5h\" or \"2h45m\"",
 		EnvVars:  []string{"FLASHBOTS_BUILDER_RATE_LIMIT_DURATION"},
 		Value:    builder.RateLimitIntervalDefault.String(),
@@ -832,6 +833,15 @@ var (
 		Usage:    "Determines the interval at which builder will resubmit block submissions",
 		EnvVars:  []string{"FLASHBOTS_BUILDER_RATE_LIMIT_RESUBMIT_INTERVAL"},
 		Value:    builder.BlockResubmitIntervalDefault.String(),
+		Category: flags.BuilderCategory,
+	}
+
+	BuilderSubmissionOffset = &cli.DurationFlag{
+		Name: "builder.submission_offset",
+		Usage: "Determines the offset from the end of slot time that the builder will submit blocks. " +
+			"For example, if a slot is 12 seconds long, and the offset is 2 seconds, the builder will submit blocks at 10 seconds into the slot.",
+		EnvVars:  []string{"FLASHBOTS_BUILDER_SUBMISSION_OFFSET"},
+		Value:    builder.SubmissionOffsetFromEndOfSlotSecondsDefault,
 		Category: flags.BuilderCategory,
 	}
 
@@ -1657,6 +1667,7 @@ func SetBuilderConfig(ctx *cli.Context, cfg *builder.Config) {
 	cfg.ValidationBlocklist = ctx.String(BuilderBlockValidationBlacklistSourceFilePath.Name)
 	cfg.BuilderRateLimitDuration = ctx.String(BuilderRateLimitDuration.Name)
 	cfg.BuilderRateLimitMaxBurst = ctx.Int(BuilderRateLimitMaxBurst.Name)
+	cfg.BuilderSubmissionOffset = ctx.Duration(BuilderSubmissionOffset.Name)
 	cfg.EnableCancellations = ctx.IsSet(BuilderEnableCancellations.Name)
 }
 


### PR DESCRIPTION
## 📝 Summary

- Based on data analysis, we find that validators make a getHeader call near the end of the slot, see: [reference#1](https://user-images.githubusercontent.com/3589723/248845576-3233df35-cc56-4b83-90d2-a0dd39a56d94.png)

- The activity of other builders indicates submissions coalesce around t-3 to t+1, where t is the end of the slot, see: [reference#2](https://user-images.githubusercontent.com/3589723/248846255-8db99720-0920-497c-9fbd-e8cb9fde2d82.png)

- Currently, Flashbots builder submits starting at t-4. 
  - This was always meant to be a temporary measure to make sure we don't risk the stability of existing builder by inducing too late a submission. 
- This task adds support for changing the submission to t-3 and exposes configurable CLI and environment variable parameters for builder submission offset. 

```
    --builder.submission_offset value (default: 3s)
          Determines the offset from the end of slot time that the builder will submit
          blocks. For example, if a slot is 12 seconds long, and the offset is 2 seconds,
          the builder will submit blocks at 10 seconds into the slot.
          [$FLASHBOTS_BUILDER_SUBMISSION_OFFSET]
```

## 📚 References

### Validator getHeader
![image](https://github.com/flashbots/builder/assets/3589723/3233df35-cc56-4b83-90d2-a0dd39a56d94)


### Builder Bid Time Range
![image](https://github.com/flashbots/builder/assets/3589723/8db99720-0920-497c-9fbd-e8cb9fde2d82)


---

* [x] I have seen and agree to [`CONTRIBUTING.md`](https://github.com/flashbots/builder/blob/main/CONTRIBUTING.md)
