### PR TITLE
Toggleable discard for failed revertible transaction hashes 

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,15 @@ $ geth --help
     --builder.cancellations        (default: false)
           Enable cancellations for the builder
 
+    --builder.discard_revertible_tx_on_error (default: false)
+          When enabled, if a transaction submitted as part of a bundle in a send bundle
+          request has error on commit, and its hash is specified as one that can revert in
+          the request body, the builder will discard the hash of the failed transaction
+          from the submitted bundle.For additional details on the structure of the request
+          body, see
+          https://docs.flashbots.net/flashbots-mev-share/searchers/understanding-bundles#bundle-definition
+          [$FLASHBOTS_BUILDER_DISCARD_REVERTIBLE_TX_ON_ERROR]
+
     --builder.dry-run              (default: false)
           Builder only validates blocks without submission to the relay
 

--- a/builder/builder.go
+++ b/builder/builder.go
@@ -72,6 +72,7 @@ type Builder struct {
 	builderPublicKey            phase0.BLSPubKey
 	builderSigningDomain        phase0.Domain
 	builderResubmitInterval     time.Duration
+	discardRevertedHashes       bool
 
 	limiter                       *rate.Limiter
 	submissionOffsetFromEndOfSlot time.Duration
@@ -91,6 +92,7 @@ type BuilderArgs struct {
 	relay                         IRelay
 	builderSigningDomain          phase0.Domain
 	builderBlockResubmitInterval  time.Duration
+	discardRevertedHashes         bool
 	eth                           IEthereumService
 	dryRun                        bool
 	ignoreLatePayloadAttributes   bool
@@ -136,6 +138,7 @@ func NewBuilder(args BuilderArgs) (*Builder, error) {
 		builderPublicKey:              pk,
 		builderSigningDomain:          args.builderSigningDomain,
 		builderResubmitInterval:       args.builderBlockResubmitInterval,
+		discardRevertedHashes:         args.discardRevertedHashes,
 		submissionOffsetFromEndOfSlot: args.submissionOffsetFromEndOfSlot,
 
 		limiter:       args.limiter,

--- a/builder/builder.go
+++ b/builder/builder.go
@@ -30,6 +30,8 @@ import (
 )
 
 const (
+	DiscardRevertedHashesDefault = false
+
 	RateLimitIntervalDefault     = 500 * time.Millisecond
 	RateLimitBurstDefault        = 10
 	BlockResubmitIntervalDefault = 500 * time.Millisecond

--- a/builder/builder.go
+++ b/builder/builder.go
@@ -30,8 +30,6 @@ import (
 )
 
 const (
-	DiscardRevertedHashesDefault = false
-
 	RateLimitIntervalDefault     = 500 * time.Millisecond
 	RateLimitBurstDefault        = 10
 	BlockResubmitIntervalDefault = 500 * time.Millisecond

--- a/builder/builder.go
+++ b/builder/builder.go
@@ -72,7 +72,7 @@ type Builder struct {
 	builderPublicKey            phase0.BLSPubKey
 	builderSigningDomain        phase0.Domain
 	builderResubmitInterval     time.Duration
-	discardRevertedHashes       bool
+	discardRevertibleTxOnErr    bool
 
 	limiter                       *rate.Limiter
 	submissionOffsetFromEndOfSlot time.Duration
@@ -92,7 +92,7 @@ type BuilderArgs struct {
 	relay                         IRelay
 	builderSigningDomain          phase0.Domain
 	builderBlockResubmitInterval  time.Duration
-	discardRevertedHashes         bool
+	discardRevertibleTxOnErr      bool
 	eth                           IEthereumService
 	dryRun                        bool
 	ignoreLatePayloadAttributes   bool
@@ -138,7 +138,7 @@ func NewBuilder(args BuilderArgs) (*Builder, error) {
 		builderPublicKey:              pk,
 		builderSigningDomain:          args.builderSigningDomain,
 		builderResubmitInterval:       args.builderBlockResubmitInterval,
-		discardRevertedHashes:         args.discardRevertedHashes,
+		discardRevertibleTxOnErr:      args.discardRevertibleTxOnErr,
 		submissionOffsetFromEndOfSlot: args.submissionOffsetFromEndOfSlot,
 
 		limiter:       args.limiter,

--- a/builder/config.go
+++ b/builder/config.go
@@ -25,6 +25,7 @@ type Config struct {
 	BuilderRateLimitMaxBurst         int           `toml:",omitempty"`
 	BuilderRateLimitResubmitInterval string        `toml:",omitempty"`
 	BuilderSubmissionOffset          time.Duration `toml:",omitempty"`
+	DiscardRevertedHashes            bool          `toml:",omitempty"`
 	EnableCancellations              bool          `toml:",omitempty"`
 }
 

--- a/builder/config.go
+++ b/builder/config.go
@@ -51,6 +51,7 @@ var DefaultConfig = Config{
 	ValidationBlocklist:           "",
 	BuilderRateLimitDuration:      RateLimitIntervalDefault.String(),
 	BuilderRateLimitMaxBurst:      RateLimitBurstDefault,
+	DiscardRevertedHashes:         false,
 	EnableCancellations:           false,
 }
 

--- a/builder/config.go
+++ b/builder/config.go
@@ -25,7 +25,7 @@ type Config struct {
 	BuilderRateLimitMaxBurst         int           `toml:",omitempty"`
 	BuilderRateLimitResubmitInterval string        `toml:",omitempty"`
 	BuilderSubmissionOffset          time.Duration `toml:",omitempty"`
-	DiscardRevertedHashes            bool          `toml:",omitempty"`
+	DiscardRevertibleTxOnErr         bool          `toml:",omitempty"`
 	EnableCancellations              bool          `toml:",omitempty"`
 }
 
@@ -51,7 +51,7 @@ var DefaultConfig = Config{
 	ValidationBlocklist:           "",
 	BuilderRateLimitDuration:      RateLimitIntervalDefault.String(),
 	BuilderRateLimitMaxBurst:      RateLimitBurstDefault,
-	DiscardRevertedHashes:         false,
+	DiscardRevertibleTxOnErr:      false,
 	EnableCancellations:           false,
 }
 

--- a/builder/service.go
+++ b/builder/service.go
@@ -289,6 +289,7 @@ func Register(stack *node.Node, backend *eth.Ethereum, cfg *Config) error {
 		builderSigningDomain:          builderSigningDomain,
 		builderBlockResubmitInterval:  builderRateLimitInterval,
 		submissionOffsetFromEndOfSlot: submissionOffset,
+		discardRevertedHashes:         cfg.DiscardRevertedHashes,
 		ignoreLatePayloadAttributes:   cfg.IgnoreLatePayloadAttributes,
 		validator:                     validator,
 		beaconClient:                  beaconClient,

--- a/builder/service.go
+++ b/builder/service.go
@@ -289,7 +289,7 @@ func Register(stack *node.Node, backend *eth.Ethereum, cfg *Config) error {
 		builderSigningDomain:          builderSigningDomain,
 		builderBlockResubmitInterval:  builderRateLimitInterval,
 		submissionOffsetFromEndOfSlot: submissionOffset,
-		discardRevertedHashes:         cfg.DiscardRevertedHashes,
+		discardRevertibleTxOnErr:      cfg.DiscardRevertibleTxOnErr,
 		ignoreLatePayloadAttributes:   cfg.IgnoreLatePayloadAttributes,
 		validator:                     validator,
 		beaconClient:                  beaconClient,

--- a/cmd/geth/main.go
+++ b/cmd/geth/main.go
@@ -179,6 +179,7 @@ var (
 		utils.BuilderRateLimitMaxBurst,
 		utils.BuilderBlockResubmitInterval,
 		utils.BuilderSubmissionOffset,
+		utils.BuilderDiscardRevertedHashes,
 		utils.BuilderEnableCancellations,
 	}
 

--- a/cmd/geth/main.go
+++ b/cmd/geth/main.go
@@ -179,7 +179,7 @@ var (
 		utils.BuilderRateLimitMaxBurst,
 		utils.BuilderBlockResubmitInterval,
 		utils.BuilderSubmissionOffset,
-		utils.BuilderDiscardRevertedHashes,
+		utils.BuilderDiscardRevertibleTxOnErr,
 		utils.BuilderEnableCancellations,
 	}
 

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -850,6 +850,9 @@ var (
 		Usage: "When enabled, if a transaction submitted as part of a bundle in a send bundle request is reverted, " +
 			"and its hash is specified as one that can revert in the request body, the builder will discard the hash of the reverted transaction from the submitted bundle." +
 			"For additional details on the structure of the request body, see https://docs.flashbots.net/flashbots-mev-share/searchers/understanding-bundles#bundle-definition",
+		EnvVars:  []string{"FLASHBOTS_BUILDER_DISCARD_REVERTED_HASHES"},
+		Value:    builder.DiscardRevertedHashesDefault,
+		Category: flags.BuilderCategory,
 	}
 
 	BuilderEnableCancellations = &cli.BoolFlag{

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -845,6 +845,13 @@ var (
 		Category: flags.BuilderCategory,
 	}
 
+	BuilderDiscardRevertedHashes = &cli.BoolFlag{
+		Name: "builder.discard_reverted_hashes",
+		Usage: "When enabled, if a transaction submitted as part of a bundle in a send bundle request is reverted, " +
+			"and its hash is specified as one that can revert in the request body, the builder will discard the hash of the reverted transaction from the submitted bundle." +
+			"For additional details on the structure of the request body, see https://docs.flashbots.net/flashbots-mev-share/searchers/understanding-bundles#bundle-definition",
+	}
+
 	BuilderEnableCancellations = &cli.BoolFlag{
 		Name:     "builder.cancellations",
 		Usage:    "Enable cancellations for the builder",
@@ -1668,6 +1675,7 @@ func SetBuilderConfig(ctx *cli.Context, cfg *builder.Config) {
 	cfg.BuilderRateLimitDuration = ctx.String(BuilderRateLimitDuration.Name)
 	cfg.BuilderRateLimitMaxBurst = ctx.Int(BuilderRateLimitMaxBurst.Name)
 	cfg.BuilderSubmissionOffset = ctx.Duration(BuilderSubmissionOffset.Name)
+	cfg.DiscardRevertedHashes = ctx.Bool(BuilderDiscardRevertedHashes.Name)
 	cfg.EnableCancellations = ctx.IsSet(BuilderEnableCancellations.Name)
 }
 

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -845,10 +845,10 @@ var (
 		Category: flags.BuilderCategory,
 	}
 
-	BuilderDiscardRevertedHashes = &cli.BoolFlag{
-		Name: "builder.discard_reverted_hashes",
-		Usage: "When enabled, if a transaction submitted as part of a bundle in a send bundle request is reverted, " +
-			"and its hash is specified as one that can revert in the request body, the builder will discard the hash of the reverted transaction from the submitted bundle." +
+	BuilderDiscardRevertibleTxOnErr = &cli.BoolFlag{
+		Name: "builder.discard_revertible_tx_on_error",
+		Usage: "When enabled, if a transaction submitted as part of a bundle in a send bundle request has error on commit, " +
+			"and its hash is specified as one that can revert in the request body, the builder will discard the hash of the failed transaction from the submitted bundle." +
 			"For additional details on the structure of the request body, see https://docs.flashbots.net/flashbots-mev-share/searchers/understanding-bundles#bundle-definition",
 		EnvVars:  []string{"FLASHBOTS_BUILDER_DISCARD_REVERTED_HASHES"},
 		Category: flags.BuilderCategory,
@@ -1677,7 +1677,7 @@ func SetBuilderConfig(ctx *cli.Context, cfg *builder.Config) {
 	cfg.BuilderRateLimitDuration = ctx.String(BuilderRateLimitDuration.Name)
 	cfg.BuilderRateLimitMaxBurst = ctx.Int(BuilderRateLimitMaxBurst.Name)
 	cfg.BuilderSubmissionOffset = ctx.Duration(BuilderSubmissionOffset.Name)
-	cfg.DiscardRevertedHashes = ctx.Bool(BuilderDiscardRevertedHashes.Name)
+	cfg.DiscardRevertibleTxOnErr = ctx.Bool(BuilderDiscardRevertibleTxOnErr.Name)
 	cfg.EnableCancellations = ctx.IsSet(BuilderEnableCancellations.Name)
 }
 

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -850,7 +850,7 @@ var (
 		Usage: "When enabled, if a transaction submitted as part of a bundle in a send bundle request has error on commit, " +
 			"and its hash is specified as one that can revert in the request body, the builder will discard the hash of the failed transaction from the submitted bundle." +
 			"For additional details on the structure of the request body, see https://docs.flashbots.net/flashbots-mev-share/searchers/understanding-bundles#bundle-definition",
-		EnvVars:  []string{"FLASHBOTS_BUILDER_DISCARD_REVERTED_HASHES"},
+		EnvVars:  []string{"FLASHBOTS_BUILDER_DISCARD_REVERTIBLE_TX_ON_ERROR"},
 		Category: flags.BuilderCategory,
 	}
 

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -877,6 +877,7 @@ var (
 			"and its hash is specified as one that can revert in the request body, the builder will discard the hash of the failed transaction from the submitted bundle." +
 			"For additional details on the structure of the request body, see https://docs.flashbots.net/flashbots-mev-share/searchers/understanding-bundles#bundle-definition",
 		EnvVars:  []string{"FLASHBOTS_BUILDER_DISCARD_REVERTIBLE_TX_ON_ERROR"},
+		Value:    builder.DefaultConfig.DiscardRevertibleTxOnErr,
 		Category: flags.BuilderCategory,
 	}
 

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -851,7 +851,6 @@ var (
 			"and its hash is specified as one that can revert in the request body, the builder will discard the hash of the reverted transaction from the submitted bundle." +
 			"For additional details on the structure of the request body, see https://docs.flashbots.net/flashbots-mev-share/searchers/understanding-bundles#bundle-definition",
 		EnvVars:  []string{"FLASHBOTS_BUILDER_DISCARD_REVERTED_HASHES"},
-		Value:    builder.DiscardRevertedHashesDefault,
 		Category: flags.BuilderCategory,
 	}
 

--- a/core/state/statedb.go
+++ b/core/state/statedb.go
@@ -129,6 +129,8 @@ type StateDB struct {
 	StorageDeleted int
 }
 
+// OriginalRoot returns the pre-state root hash before any changes were made.
+// NOTE: This method is not safe for concurrent use.
 func (s *StateDB) OriginalRoot() common.Hash {
 	return s.originalRoot
 }

--- a/core/state/statedb.go
+++ b/core/state/statedb.go
@@ -129,6 +129,10 @@ type StateDB struct {
 	StorageDeleted int
 }
 
+func (s *StateDB) OriginalRoot() common.Hash {
+	return s.originalRoot
+}
+
 // New creates a new state from a given trie.
 func New(root common.Hash, db Database, snaps *snapshot.Tree) (*StateDB, error) {
 	tr, err := db.OpenTrie(root)

--- a/core/state/statedb.go
+++ b/core/state/statedb.go
@@ -129,12 +129,6 @@ type StateDB struct {
 	StorageDeleted int
 }
 
-// OriginalRoot returns the pre-state root hash before any changes were made.
-// NOTE: This method is not safe for concurrent use.
-func (s *StateDB) OriginalRoot() common.Hash {
-	return s.originalRoot
-}
-
 // New creates a new state from a given trie.
 func New(root common.Hash, db Database, snaps *snapshot.Tree) (*StateDB, error) {
 	tr, err := db.OpenTrie(root)

--- a/miner/algo_common.go
+++ b/miner/algo_common.go
@@ -207,6 +207,8 @@ func (envDiff *environmentDiff) commitTx(tx *types.Transaction, chData chainData
 	// 2. if the transaction receipt status is failed
 	// we don't apply the transaction to the state and we don't add it to the newTxs, return early
 	if algoConf.DropTransactionOnRevert && (err != nil || (receipt != nil && receipt.Status == types.ReceiptStatusFailed)) {
+		// the StateDB for environment diff is already modified at this point, since it gets mutated when passed in to
+		// applyTransactionWithBlacklist, so we need to revert it
 		s, sdbErr := state.New(root, envDiff.state.Database(), chData.chain.Snapshots())
 		// if we cannot create a new state from the existing database, snapshots, and intermediate root hash,
 		// we panic because this is a fatal error

--- a/miner/algo_common.go
+++ b/miner/algo_common.go
@@ -327,9 +327,11 @@ func (envDiff *environmentDiff) commitBundle(bundle *types.SimulatedBundle, chDa
 		hasErr = err != nil
 		hasReceiptFailed = receipt != nil && receipt.Status == types.ReceiptStatusFailed
 
-		// if drop transaction on revert is enabled and the transaction is found in list of reverting transaction hashes,
-		// when there was an error applying the transaction OR
-		// the transaction failed, we skip the transaction and continue with the next one
+		// if drop transaction on revert is enabled and the transaction is found in list of reverting transaction hashes:
+		// 1. when there was an error applying the transaction OR
+		// 2. the transaction failed
+		//
+		// we skip the transaction and continue with the next one
 		if canDiscard && (hasErr || hasReceiptFailed) {
 			log.Trace("Failed to commit bundle transaction, but drop transaction on revert is enabled, skipping",
 				"bundle", bundle.OriginalBundle.Hash, "tx", tx.Hash(), "err", err, "receipt-failed", hasReceiptFailed)

--- a/miner/algo_common.go
+++ b/miner/algo_common.go
@@ -209,7 +209,7 @@ func (envDiff *environmentDiff) commitTx(tx *types.Transaction, chData chainData
 	// 2. if the transaction receipt status is failed
 	// we don't apply the transaction to the state and we don't add it to the newTxs, return early
 	// NOTE: We only drop transaction when its specified in reverting transaction hashes for bundles and sbundles.
-	//   Calling commitTx for a single transaction should set the boolean to false and not drop the transaction.
+	//   Calling commitTx for a single transaction should set canRevert to false and not drop the transaction.
 	if algoConf.DropTransactionOnRevert && algoConf.canRevert &&
 		(err != nil || (receipt != nil && receipt.Status == types.ReceiptStatusFailed)) {
 		// the StateDB for environment diff is already modified at this point, since it gets mutated when passed in to

--- a/miner/algo_common.go
+++ b/miner/algo_common.go
@@ -311,7 +311,7 @@ func (envDiff *environmentDiff) commitBundle(bundle *types.SimulatedBundle, chDa
 			isRevertibleTx := bundle.OriginalBundle.RevertingHash(txHash)
 			// if drop enabled, and revertible tx has error on commit, we skip the transaction and continue with next one
 			if algoConf.DropRevertibleTxOnErr && isRevertibleTx {
-				log.Debug("Found error on commit for revertible tx, but discard on err is enabled so skipping.",
+				log.Trace("Found error on commit for revertible tx, but discard on err is enabled so skipping.",
 					"tx", txHash, "err", err)
 				continue
 			}
@@ -596,7 +596,7 @@ func (envDiff *environmentDiff) commitSBundleInner(
 				// if drop enabled, and revertible tx has error on commit,
 				// we skip the transaction and continue with next one
 				if algoConf.DropRevertibleTxOnErr && el.CanRevert {
-					log.Debug("Found error on commit for revertible tx, but discard on err is enabled so skipping.",
+					log.Trace("Found error on commit for revertible tx, but discard on err is enabled so skipping.",
 						"tx", el.Tx.Hash(), "err", err)
 					continue
 				}

--- a/miner/algo_common.go
+++ b/miner/algo_common.go
@@ -607,9 +607,9 @@ func (envDiff *environmentDiff) commitSBundleInner(
 	}
 
 	var (
-		// Store the initial value for DropTransactionOnRevert as it will be mutated in the loop depending on whether a given transaction is revertible or not.
+		// Store the initial value for canRevert as it will be mutated in the loop depending on whether a given transaction is revertible or not.
 		// Only sbundles and bundles currently support specifying revertible transactions.
-		discard                   = algoConf.DropTransactionOnRevert
+		canRevertDefault          = algoConf.canRevert
 		totalProfit      *big.Int = new(big.Int)
 		refundableProfit *big.Int = new(big.Int)
 
@@ -625,10 +625,10 @@ func (envDiff *environmentDiff) commitSBundleInner(
 			// We only want to drop reverted transactions if they are specified as ones that can revert
 			// when they are submitted to the builder. Only bundles and sbundles currently support specifying
 			// revertible transactions.
-			algoConf.DropTransactionOnRevert = discard && el.CanRevert
+			algoConf.canRevert = el.CanRevert
 			receipt, _, err := envDiff.commitTx(el.Tx, chData, algoConf)
 			// reset value for subsequent transactions or bundles
-			algoConf.DropTransactionOnRevert = discard
+			algoConf.canRevert = canRevertDefault
 
 			if err != nil {
 				return err

--- a/miner/algo_common.go
+++ b/miner/algo_common.go
@@ -64,7 +64,7 @@ type algorithmConfig struct {
 	// for committing a transaction based on ProfitThresholdPercent
 	EnforceProfit bool
 	// ProfitThresholdPercent is the minimum profit threshold for committing a transaction
-	ProfitThresholdPercent int
+	ProfitThresholdPercent int // 0-100, e.g. 70 means 70%
 }
 
 type chainData struct {

--- a/miner/algo_common_test.go
+++ b/miner/algo_common_test.go
@@ -234,7 +234,6 @@ func newEnvironment(data chainData, state *state.StateDB, coinbase common.Addres
 }
 
 func TestTxCommit(t *testing.T) {
-	algoConf := defaultAlgorithmConfig
 	statedb, chData, signers := genTestSetup()
 
 	env := newEnvironment(chData, statedb, signers.addresses[0], GasLimit, big.NewInt(1))
@@ -242,7 +241,7 @@ func TestTxCommit(t *testing.T) {
 
 	tx := signers.signTx(1, 21000, big.NewInt(0), big.NewInt(1), signers.addresses[2], big.NewInt(0), []byte{})
 
-	receipt, i, err := envDiff.commitTx(tx, chData, algoConf)
+	receipt, i, err := envDiff.commitTx(tx, chData)
 	if err != nil {
 		t.Fatal("can't commit transaction:", err)
 	}
@@ -325,7 +324,7 @@ func TestErrorTxCommit(t *testing.T) {
 	signers.nonces[1] = 10
 	tx := signers.signTx(1, 21000, big.NewInt(0), big.NewInt(1), signers.addresses[2], big.NewInt(0), []byte{})
 
-	_, i, err := envDiff.commitTx(tx, chData, defaultAlgorithmConfig)
+	_, i, err := envDiff.commitTx(tx, chData)
 	if err == nil {
 		t.Fatal("committed incorrect transaction:", err)
 	}
@@ -359,7 +358,7 @@ func TestCommitTxOverGasLimit(t *testing.T) {
 	tx1 := signers.signTx(1, 21000, big.NewInt(0), big.NewInt(1), signers.addresses[2], big.NewInt(0), []byte{})
 	tx2 := signers.signTx(1, 21000, big.NewInt(0), big.NewInt(1), signers.addresses[2], big.NewInt(0), []byte{})
 
-	receipt, i, err := envDiff.commitTx(tx1, chData, defaultAlgorithmConfig)
+	receipt, i, err := envDiff.commitTx(tx1, chData)
 	if err != nil {
 		t.Fatal("can't commit transaction:", err)
 	}
@@ -374,7 +373,7 @@ func TestCommitTxOverGasLimit(t *testing.T) {
 		t.Fatal("Env diff gas pool is not drained")
 	}
 
-	_, _, err = envDiff.commitTx(tx2, chData, defaultAlgorithmConfig)
+	_, _, err = envDiff.commitTx(tx2, chData)
 	require.Error(t, err, "committed tx over gas limit")
 }
 
@@ -400,7 +399,7 @@ func TestErrorBundleCommit(t *testing.T) {
 		t.Fatal("Failed to simulate bundle", err)
 	}
 
-	_, _, err = envDiff.commitTx(tx0, chData, defaultAlgorithmConfig)
+	_, _, err = envDiff.commitTx(tx0, chData)
 	if err != nil {
 		t.Fatal("Failed to commit tx0", err)
 	}
@@ -441,7 +440,6 @@ func TestErrorBundleCommit(t *testing.T) {
 }
 
 func TestBlacklist(t *testing.T) {
-	algoConf := defaultAlgorithmConfig
 	statedb, chData, signers := genTestSetup()
 
 	env := newEnvironment(chData, statedb, signers.addresses[0], GasLimit, big.NewInt(1))
@@ -459,13 +457,13 @@ func TestBlacklist(t *testing.T) {
 	balanceBefore := envDiff.state.GetBalance(signers.addresses[3])
 
 	tx := signers.signTx(1, 21000, big.NewInt(0), big.NewInt(1), signers.addresses[3], big.NewInt(77), []byte{})
-	_, _, err := envDiff.commitTx(tx, chData, algoConf)
+	_, _, err := envDiff.commitTx(tx, chData)
 	if err == nil {
 		t.Fatal("committed blacklisted transaction: to")
 	}
 
 	tx = signers.signTx(3, 21000, big.NewInt(0), big.NewInt(1), signers.addresses[1], big.NewInt(88), []byte{})
-	_, _, err = envDiff.commitTx(tx, chData, algoConf)
+	_, _, err = envDiff.commitTx(tx, chData)
 	if err == nil {
 		t.Fatal("committed blacklisted transaction: sender")
 	}
@@ -474,19 +472,19 @@ func TestBlacklist(t *testing.T) {
 	calldata = append(calldata, signers.addresses[3].Bytes()...)
 
 	tx = signers.signTx(4, 40000, big.NewInt(0), big.NewInt(1), payProxyAddress, big.NewInt(99), calldata)
-	_, _, err = envDiff.commitTx(tx, chData, algoConf)
+	_, _, err = envDiff.commitTx(tx, chData)
 	if err == nil {
 		t.Fatal("committed blacklisted transaction: trace")
 	}
 
 	tx = signers.signTx(5, 40000, big.NewInt(0), big.NewInt(1), payProxyAddress, big.NewInt(0), calldata)
-	_, _, err = envDiff.commitTx(tx, chData, algoConf)
+	_, _, err = envDiff.commitTx(tx, chData)
 	if err == nil {
 		t.Fatal("committed blacklisted transaction: trace, zero value")
 	}
 
 	tx = signers.signTx(6, 30000, big.NewInt(0), big.NewInt(1), payProxyAddress, big.NewInt(99), calldata)
-	_, _, err = envDiff.commitTx(tx, chData, algoConf)
+	_, _, err = envDiff.commitTx(tx, chData)
 	if err == nil {
 		t.Fatal("committed blacklisted transaction: trace, failed tx")
 	}

--- a/miner/algo_greedy.go
+++ b/miner/algo_greedy.go
@@ -53,7 +53,12 @@ func (b *greedyBuilder) mergeOrdersIntoEnvDiff(
 		}
 
 		if tx := order.Tx(); tx != nil {
-			receipt, skip, err := envDiff.commitTx(tx, b.chainData, b.algoConf)
+			// We only want to drop reverted transactions if they are specified as ones that can revert
+			// when they are submitted to the builder. Only bundles and sbundles currently support specifying
+			// revertible transactions.
+			algoConf := b.algoConf
+			algoConf.DropTransactionOnRevert = false
+			receipt, skip, err := envDiff.commitTx(tx, b.chainData, algoConf)
 			switch skip {
 			case shiftTx:
 				orders.Shift()

--- a/miner/algo_greedy.go
+++ b/miner/algo_greedy.go
@@ -42,7 +42,7 @@ func (b *greedyBuilder) mergeOrdersIntoEnvDiff(envDiff *environmentDiff, orders 
 		}
 
 		if tx := order.Tx(); tx != nil {
-			receipt, skip, err := envDiff.commitTx(tx, b.chainData)
+			receipt, skip, err := envDiff.commitTx(tx, b.chainData, false)
 			switch skip {
 			case shiftTx:
 				orders.Shift()

--- a/miner/algo_greedy.go
+++ b/miner/algo_greedy.go
@@ -57,7 +57,7 @@ func (b *greedyBuilder) mergeOrdersIntoEnvDiff(
 			// when they are submitted to the builder. Only bundles and sbundles currently support specifying
 			// revertible transactions.
 			algoConf := b.algoConf
-			algoConf.DropTransactionOnRevert = false
+			algoConf.canRevert = false
 			receipt, skip, err := envDiff.commitTx(tx, b.chainData, algoConf)
 			switch skip {
 			case shiftTx:

--- a/miner/algo_greedy.go
+++ b/miner/algo_greedy.go
@@ -89,7 +89,7 @@ func (b *greedyBuilder) mergeOrdersIntoEnvDiff(
 			usedEntry := types.UsedSBundle{
 				Bundle: sbundle.Bundle,
 			}
-			err := envDiff.commitSBundle(sbundle, b.chainData, b.interrupt, b.builderKey, defaultAlgorithmConfig)
+			err := envDiff.commitSBundle(sbundle, b.chainData, b.interrupt, b.builderKey, b.algoConf)
 			orders.Pop()
 			if err != nil {
 				log.Trace("Could not apply sbundle", "bundle", sbundle.Bundle.Hash(), "err", err)

--- a/miner/algo_greedy.go
+++ b/miner/algo_greedy.go
@@ -53,12 +53,7 @@ func (b *greedyBuilder) mergeOrdersIntoEnvDiff(
 		}
 
 		if tx := order.Tx(); tx != nil {
-			// We only want to drop reverted transactions if they are specified as ones that can revert
-			// when they are submitted to the builder. Only bundles and sbundles currently support specifying
-			// revertible transactions.
-			algoConf := b.algoConf
-			algoConf.canRevert = false
-			receipt, skip, err := envDiff.commitTx(tx, b.chainData, algoConf)
+			receipt, skip, err := envDiff.commitTx(tx, b.chainData)
 			switch skip {
 			case shiftTx:
 				orders.Shift()

--- a/miner/algo_greedy_buckets.go
+++ b/miner/algo_greedy_buckets.go
@@ -98,7 +98,7 @@ func (b *greedyBucketsBuilder) commit(envDiff *environmentDiff,
 			// when they are submitted to the builder. Only bundles and sbundles currently support specifying
 			// revertible transactions.
 			algoConf := b.algoConf
-			algoConf.DropTransactionOnRevert = false
+			algoConf.canRevert = false
 			receipt, skip, err := envDiff.commitTx(tx, b.chainData, algoConf)
 			if err != nil {
 				log.Trace("could not apply tx", "hash", tx.Hash(), "err", err)

--- a/miner/algo_greedy_buckets.go
+++ b/miner/algo_greedy_buckets.go
@@ -94,12 +94,7 @@ func (b *greedyBucketsBuilder) commit(envDiff *environmentDiff,
 
 	for _, order := range transactions {
 		if tx := order.Tx(); tx != nil {
-			// We only want to drop reverted transactions if they are specified as ones that can revert
-			// when they are submitted to the builder. Only bundles and sbundles currently support specifying
-			// revertible transactions.
-			algoConf := b.algoConf
-			algoConf.canRevert = false
-			receipt, skip, err := envDiff.commitTx(tx, b.chainData, algoConf)
+			receipt, skip, err := envDiff.commitTx(tx, b.chainData)
 			if err != nil {
 				log.Trace("could not apply tx", "hash", tx.Hash(), "err", err)
 

--- a/miner/algo_greedy_test.go
+++ b/miner/algo_greedy_test.go
@@ -30,7 +30,7 @@ func TestBuildBlockGasLimit(t *testing.T) {
 		var result *environment
 		switch algo {
 		case ALGO_GREEDY_BUCKETS:
-			builder := newGreedyBuilder(chData.chain, chData.chainConfig, nil, env, nil, nil)
+			builder := newGreedyBuilder(chData.chain, chData.chainConfig, nil, nil, env, nil, nil)
 			result, _, _ = builder.buildBlock([]types.SimulatedBundle{}, nil, txs)
 		case ALGO_GREEDY:
 			builder := newGreedyBucketsBuilder(chData.chain, chData.chainConfig, nil, nil, env, nil, nil)

--- a/miner/algo_test.go
+++ b/miner/algo_test.go
@@ -39,6 +39,7 @@ var algoTests = []*algoTest{
 		},
 		WantProfit:          big.NewInt(2 * 21_000),
 		SupportedAlgorithms: []AlgoType{ALGO_GREEDY, ALGO_GREEDY_BUCKETS},
+		AlgorithmConfig:     defaultAlgorithmConfig,
 	},
 	{
 		// Trivial tx pool with 3 txs by two accounts and a block gas limit that only allows two txs
@@ -65,6 +66,7 @@ var algoTests = []*algoTest{
 		},
 		WantProfit:          big.NewInt(4 * 21_000),
 		SupportedAlgorithms: []AlgoType{ALGO_GREEDY, ALGO_GREEDY_BUCKETS},
+		AlgorithmConfig:     defaultAlgorithmConfig,
 	},
 	{
 		// Trivial bundle with one tx that reverts but is not allowed to revert.
@@ -83,6 +85,7 @@ var algoTests = []*algoTest{
 		},
 		WantProfit:          big.NewInt(0),
 		SupportedAlgorithms: []AlgoType{ALGO_GREEDY, ALGO_GREEDY_BUCKETS},
+		AlgorithmConfig:     defaultAlgorithmConfig,
 	},
 	{
 		// Trivial bundle with one tx that reverts and is allowed to revert.
@@ -104,6 +107,33 @@ var algoTests = []*algoTest{
 		},
 		WantProfit:          big.NewInt(50_000),
 		SupportedAlgorithms: []AlgoType{ALGO_GREEDY, ALGO_GREEDY_BUCKETS},
+		AlgorithmConfig:     defaultAlgorithmConfig,
+	},
+	{
+		// Trivial bundle with one tx that reverts and is allowed to revert.
+		//
+		// Bundle should NOT be included since DropTransactionOnRevert is enabled.
+		Name:   "atomic-bundle-revert-and-discard",
+		Header: &types.Header{GasLimit: 50_000},
+		Alloc: []core.GenesisAccount{
+			{Balance: big.NewInt(50_000)},
+			{Code: contractRevert},
+		},
+		Bundles: func(acc accByIndex, sign signByIndex, txs txByAccIndexAndNonce) []*bundle {
+			return []*bundle{
+				{
+					Txs:                types.Transactions{sign(0, &types.LegacyTx{Nonce: 0, Gas: 50_000, To: acc(1), GasPrice: big.NewInt(1)})},
+					RevertingTxIndices: []int{0},
+				},
+			}
+		},
+		WantProfit:          common.Big0,
+		SupportedAlgorithms: []AlgoType{ALGO_GREEDY, ALGO_GREEDY_BUCKETS},
+		AlgorithmConfig: algorithmConfig{
+			DropTransactionOnRevert: true,
+			EnforceProfit:           defaultAlgorithmConfig.EnforceProfit,
+			ProfitThresholdPercent:  defaultAlgorithmConfig.ProfitThresholdPercent,
+		},
 	},
 	{
 		// Single failing tx that is included in the tx pool and in a bundle that is not allowed to
@@ -130,6 +160,7 @@ var algoTests = []*algoTest{
 		},
 		WantProfit:          big.NewInt(50_000),
 		SupportedAlgorithms: []AlgoType{ALGO_GREEDY, ALGO_GREEDY_BUCKETS},
+		AlgorithmConfig:     defaultAlgorithmConfig,
 	},
 }
 
@@ -152,7 +183,7 @@ func TestAlgo(t *testing.T) {
 					t.Fatalf("Simulate Bundles: %v", err)
 				}
 
-				gotProfit, err := runAlgoTest(algo, config, alloc, txPool, simBundles, test.Header, 1)
+				gotProfit, err := runAlgoTest(algo, test.AlgorithmConfig, config, alloc, txPool, simBundles, test.Header, 1)
 				if err != nil {
 					t.Fatal(err)
 				}
@@ -203,7 +234,7 @@ func BenchmarkAlgo(b *testing.B) {
 							}
 						}()
 
-						gotProfit, err := runAlgoTest(algo, config, alloc, txPoolCopy, simBundles, test.Header, scale)
+						gotProfit, err := runAlgoTest(algo, test.AlgorithmConfig, config, alloc, txPoolCopy, simBundles, test.Header, scale)
 						if err != nil {
 							b.Fatal(err)
 						}
@@ -218,8 +249,11 @@ func BenchmarkAlgo(b *testing.B) {
 }
 
 // runAlgo executes a single algoTest case and returns the profit.
-func runAlgoTest(algo AlgoType, config *params.ChainConfig, alloc core.GenesisAlloc,
-	txPool map[common.Address]types.Transactions, bundles []types.SimulatedBundle, header *types.Header, scale int) (gotProfit *big.Int, err error) {
+func runAlgoTest(
+	algo AlgoType, algoConf algorithmConfig,
+	config *params.ChainConfig, alloc core.GenesisAlloc,
+	txPool map[common.Address]types.Transactions, bundles []types.SimulatedBundle, header *types.Header, scale int,
+) (gotProfit *big.Int, err error) {
 	var (
 		statedb, chData = genTestSetupWithAlloc(config, alloc)
 		env             = newEnvironment(chData, statedb, header.Coinbase, header.GasLimit*uint64(scale), header.BaseFee)
@@ -229,10 +263,10 @@ func runAlgoTest(algo AlgoType, config *params.ChainConfig, alloc core.GenesisAl
 	// build block
 	switch algo {
 	case ALGO_GREEDY_BUCKETS:
-		builder := newGreedyBucketsBuilder(chData.chain, chData.chainConfig, nil, nil, env, nil, nil)
+		builder := newGreedyBucketsBuilder(chData.chain, chData.chainConfig, &algoConf, nil, env, nil, nil)
 		resultEnv, _, _ = builder.buildBlock(bundles, nil, txPool)
 	case ALGO_GREEDY:
-		builder := newGreedyBuilder(chData.chain, chData.chainConfig, nil, env, nil, nil)
+		builder := newGreedyBuilder(chData.chain, chData.chainConfig, &algoConf, nil, env, nil, nil)
 		resultEnv, _, _ = builder.buildBlock(bundles, nil, txPool)
 	}
 	return resultEnv.profit, nil
@@ -280,6 +314,8 @@ type algoTest struct {
 	WantProfit *big.Int // Expected block profit
 
 	SupportedAlgorithms []AlgoType
+
+	AlgorithmConfig algorithmConfig
 }
 
 // setDefaults sets default values for the algoTest.

--- a/miner/multi_worker.go
+++ b/miner/multi_worker.go
@@ -201,9 +201,10 @@ func newMultiWorkerMevGeth(config *Config, chainConfig *params.ChainConfig, engi
 }
 
 type flashbotsData struct {
-	isFlashbots      bool
-	queue            chan *task
-	maxMergedBundles int
-	algoType         AlgoType
-	bundleCache      *BundleCache
+	isFlashbots           bool
+	queue                 chan *task
+	maxMergedBundles      int
+	algoType              AlgoType
+	bundleCache           *BundleCache
+	discardRevertedHashes bool
 }

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -1913,7 +1913,10 @@ func containsHash(arr []common.Hash, match common.Hash) bool {
 
 // Compute the adjusted gas price for a whole bundle
 // Done by calculating all gas spent, adding transfers to the coinbase, and then dividing by gas used
-func (w *worker) computeBundleGas(env *environment, bundle types.MevBundle, state *state.StateDB, gasPool *core.GasPool, pendingTxs map[common.Address]types.Transactions, currentTxCount int) (simulatedBundle, error) {
+func (w *worker) computeBundleGas(
+	env *environment, bundle types.MevBundle, state *state.StateDB, gasPool *core.GasPool,
+	pendingTxs map[common.Address]types.Transactions, currentTxCount int,
+) (simulatedBundle, error) {
 	var totalGasUsed uint64 = 0
 	var tempGasUsed uint64
 	gasFees := new(big.Int)

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -1404,9 +1404,9 @@ func (w *worker) fillTransactionsAlgoWorker(interrupt *int32, env *environment) 
 	switch w.flashbots.algoType {
 	case ALGO_GREEDY_BUCKETS:
 		algoConf := &algorithmConfig{
-			DropTransactionOnRevert: w.flashbots.discardRevertedHashes,
-			EnforceProfit:           true,
-			ProfitThresholdPercent:  defaultProfitPercentMinimum,
+			DropRevertibleTxOnErr:  w.flashbots.discardRevertedHashes,
+			EnforceProfit:          true,
+			ProfitThresholdPercent: defaultProfitPercentMinimum,
 		}
 		builder := newGreedyBucketsBuilder(
 			w.chain, w.chainConfig, algoConf, w.blockList, env,
@@ -1418,11 +1418,11 @@ func (w *worker) fillTransactionsAlgoWorker(interrupt *int32, env *environment) 
 		fallthrough
 	default:
 		// For default greedy builder, set algorithm configuration to default values,
-		// except DropTransactionOnRevert which is passed in from worker config
+		// except DropRevertibleTxOnErr which is passed in from worker config
 		algoConf := &algorithmConfig{
-			DropTransactionOnRevert: w.flashbots.discardRevertedHashes,
-			EnforceProfit:           defaultAlgorithmConfig.EnforceProfit,
-			ProfitThresholdPercent:  defaultAlgorithmConfig.ProfitThresholdPercent,
+			DropRevertibleTxOnErr:  w.flashbots.discardRevertedHashes,
+			EnforceProfit:          defaultAlgorithmConfig.EnforceProfit,
+			ProfitThresholdPercent: defaultAlgorithmConfig.ProfitThresholdPercent,
 		}
 		builder := newGreedyBuilder(
 			w.chain, w.chainConfig, algoConf, w.blockList, env,


### PR DESCRIPTION
## 📝 Summary

<!--- A general summary of your changes -->
- Current behavior of bundles is that:
  1. All transactions in a bundle must be included in specified order, with no transaction inserted between them, **OR** 
  2. If any transaction reverts, then no transaction from the bundle will be included **EXCEPT**
  3. When user specifies **reverting transaction hashes** in their request, the builder can still include the bundle with one or more of the transactions failing within it

- This PR makes it so when users specify reverting transaction hashes in their request, the builder **discards** the transaction(s) on **error**

### Changes 
- Add toggleable support for discarding reverted transaction hashes on error
- When a transaction that's part of a bundle fails, and the request sent to the builder sets field to allow revert for the transaction hash, the builder will discard the hash of the failed transaction from the submitted bundle. 
  - For additional details on the structure of the request body, see https://docs.flashbots.net/flashbots-mev-share/searchers/understanding-bundles#bundle-definition 

## 📚 References

<!-- Any interesting external links to documentation, articles, tweets which add value to the PR -->
- https://docs.flashbots.net/flashbots-mev-share/searchers/understanding-bundles#bundle-definition

---

* [x] I have seen and agree to [`CONTRIBUTING.md`](https://github.com/flashbots/builder/blob/main/CONTRIBUTING.md)
