### PR TITLE
[trivial] Parameterize greedy-buckets price cutoff percent & update bundle profit to coinbase delta

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ $ geth --help
     --miner.extradata value
           Block extra data set by the miner (default = client version)
 
-    --miner.price_cutoff_percent value (default: -1)
+    --miner.price_cutoff_percent value (default: 50)
           flashbots - The minimum effective gas price threshold used for bucketing
           transactions by price. For example if the top transaction in a list has an
           effective gas price of 1000 wei and price_cutoff_percent is 10 (i.e. 10%), then

--- a/README.md
+++ b/README.md
@@ -130,6 +130,15 @@ $ geth --help
     --miner.extradata value
           Block extra data set by the miner (default = client version)
 
+    --miner.price_cutoff_percent value (default: -1)
+          flashbots - The minimum effective gas price threshold used for bucketing
+          transactions by price. For example if the top transaction in a list has an
+          effective gas price of 1000 wei and price_cutoff_percent is 10 (i.e. 10%), then
+          the minimum effective gas price included in the same bucket as the top
+          transaction is (1000 * 10%) = 100 wei.
+          NOTE: This flag is only used when
+          miner.algotype=greedy-buckets
+
    METRICS
 
    --metrics.builder value          (default: false)

--- a/cmd/geth/main.go
+++ b/cmd/geth/main.go
@@ -133,6 +133,7 @@ var (
 		utils.MinerMaxMergedBundlesFlag,
 		utils.MinerBlocklistFileFlag,
 		utils.MinerNewPayloadTimeout,
+		utils.MinerPriceCutoffPercentFlag,
 		utils.NATFlag,
 		utils.NoDiscoverFlag,
 		utils.DiscoveryV5Flag,

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -548,7 +548,7 @@ var (
 	}
 	MinerAlgoTypeFlag = &cli.StringFlag{
 		Name:     "miner.algotype",
-		Usage:    "Block building algorithm to use [=mev-geth] (mev-geth, greedy)",
+		Usage:    "Block building algorithm to use [=mev-geth] (mev-geth, greedy, greedy-buckets)",
 		Value:    "mev-geth",
 		Category: flags.MinerCategory,
 	}
@@ -590,6 +590,17 @@ var (
 		Usage:    "Specify the maximum time allowance for creating a new payload",
 		Value:    ethconfig.Defaults.Miner.NewPayloadTimeout,
 		Category: flags.MinerCategory,
+	}
+	MinerPriceCutoffPercentFlag = &cli.IntFlag{
+		Name: "miner.price_cutoff_percent",
+		Usage: "flashbots - The minimum effective gas price threshold used for bucketing transactions by price. " +
+			"For example if the top transaction in a list has an effective gas price of 1000 wei and price_cutoff_percent " +
+			"is 10 (i.e. 10%), then the minimum effective gas price included in the same bucket as the top transaction " +
+			"is (1000 * 10%) = 100 wei.\n" +
+			"NOTE: This flag is only used when miner.algotype=greedy-buckets",
+		Value:    -1,
+		Category: flags.MinerCategory,
+		EnvVars:  []string{"FLASHBOTS_MINER_PRICE_CUTOFF_PERCENT"},
 	}
 
 	// Account settings
@@ -1893,6 +1904,8 @@ func setMiner(ctx *cli.Context, cfg *miner.Config) {
 			Fatalf("Failed to parse blocklist: %s", err)
 		}
 	}
+
+	cfg.PriceCutoffPercent = ctx.Int(MinerPriceCutoffPercentFlag.Name)
 }
 
 func setRequiredBlocks(ctx *cli.Context, cfg *ethconfig.Config) {

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -598,7 +598,7 @@ var (
 			"is 10 (i.e. 10%), then the minimum effective gas price included in the same bucket as the top transaction " +
 			"is (1000 * 10%) = 100 wei.\n" +
 			"NOTE: This flag is only used when miner.algotype=greedy-buckets",
-		Value:    -1,
+		Value:    ethconfig.Defaults.Miner.PriceCutoffPercent,
 		Category: flags.MinerCategory,
 		EnvVars:  []string{"FLASHBOTS_MINER_PRICE_CUTOFF_PERCENT"},
 	}

--- a/core/types/transaction.go
+++ b/core/types/transaction.go
@@ -535,7 +535,7 @@ func (t *TxWithMinerFee) Profit(baseFee *big.Int, gasUsed uint64) *big.Int {
 		}
 		return profit
 	} else if bundle := t.Bundle(); bundle != nil {
-		return bundle.TotalEth
+		return bundle.EthSentToCoinbase
 	} else if sbundle := t.SBundle(); sbundle != nil {
 		return sbundle.Profit
 	} else {

--- a/miner/algo_common.go
+++ b/miner/algo_common.go
@@ -22,9 +22,14 @@ const (
 	popTx   = 2
 )
 
-// defaultProfitPercentMinimum is to ensure committed transactions, bundles, sbundles don't fall below this threshold
-// when profit is enforced
-const defaultProfitPercentMinimum = 70
+const (
+	// defaultProfitPercentMinimum is to ensure committed transactions, bundles, sbundles don't fall below this threshold
+	// when profit is enforced
+	defaultProfitPercentMinimum = 70
+
+	// defaultPriceCutoffPercent is for bucketing transactions by price, used for greedy buckets algorithm
+	defaultPriceCutoffPercent = 50
+)
 
 var (
 	defaultProfitThreshold = big.NewInt(defaultProfitPercentMinimum)
@@ -63,6 +68,11 @@ type algorithmConfig struct {
 	ExpectedProfit *big.Int
 	// ProfitThresholdPercent is the minimum profit threshold for committing a transaction
 	ProfitThresholdPercent *big.Int
+	// PriceCutoffPercent is the minimum effective gas price threshold used for bucketing transactions by price.
+	// For example if the top transaction in a list has an effective gas price of 1000 wei and PriceCutoffPercent
+	// is 10 (i.e. 10%), then the minimum effective gas price included in the same bucket as the top transaction
+	// is (1000 * 10%) = 100 wei.
+	PriceCutoffPercent int
 }
 
 type chainData struct {

--- a/miner/miner.go
+++ b/miner/miner.go
@@ -110,8 +110,9 @@ var DefaultConfig = Config{
 	// consensus-layer usually will wait a half slot of time(6s)
 	// for payload generation. It should be enough for Geth to
 	// run 3 rounds.
-	Recommit:          2 * time.Second,
-	NewPayloadTimeout: 2 * time.Second,
+	Recommit:           2 * time.Second,
+	NewPayloadTimeout:  2 * time.Second,
+	PriceCutoffPercent: defaultPriceCutoffPercent,
 }
 
 // Miner creates blocks and searches for proof-of-work values.

--- a/miner/miner.go
+++ b/miner/miner.go
@@ -98,6 +98,7 @@ type Config struct {
 	MaxMergedBundles    int
 	Blocklist           []common.Address `toml:",omitempty"`
 	NewPayloadTimeout   time.Duration    // The maximum time allowance for creating a new payload
+	PriceCutoffPercent  int              // Effective gas price cutoff % used for bucketing transactions by price (only useful in greedy-buckets AlgoType)
 }
 
 // DefaultConfig contains default settings for miner.

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -1405,13 +1405,8 @@ func (w *worker) fillTransactionsAlgoWorker(interrupt *int32, env *environment) 
 
 	switch w.flashbots.algoType {
 	case ALGO_GREEDY_BUCKETS:
-		var priceCutoffPercent int
-		if percent := w.config.PriceCutoffPercent; percent == -1 {
-			// default config percent value is -1, which means that the price cutoff percent is not set
-			priceCutoffPercent = defaultPriceCutoffPercent
-		} else if percent >= 0 && percent <= 100 {
-			priceCutoffPercent = percent
-		} else {
+		priceCutoffPercent := w.config.PriceCutoffPercent
+		if !(priceCutoffPercent >= 0 && priceCutoffPercent <= 100) {
 			return nil, nil, nil, errors.New("invalid price cutoff percent - must be between 0 and 100")
 		}
 

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -1405,13 +1405,24 @@ func (w *worker) fillTransactionsAlgoWorker(interrupt *int32, env *environment) 
 
 	switch w.flashbots.algoType {
 	case ALGO_GREEDY_BUCKETS:
-		validationConf := &algorithmConfig{
+		var priceCutoffPercent int
+		if percent := w.config.PriceCutoffPercent; percent == -1 {
+			// default config percent value is -1, which means that the price cutoff percent is not set
+			priceCutoffPercent = defaultPriceCutoffPercent
+		} else if percent >= 0 && percent <= 100 {
+			priceCutoffPercent = percent
+		} else {
+			return nil, nil, nil, errors.New("invalid price cutoff percent - must be between 0 and 100")
+		}
+
+		algoConf := &algorithmConfig{
 			EnforceProfit:          true,
 			ExpectedProfit:         nil,
 			ProfitThresholdPercent: defaultProfitThreshold,
+			PriceCutoffPercent:     priceCutoffPercent,
 		}
 		builder := newGreedyBucketsBuilder(
-			w.chain, w.chainConfig, validationConf, w.blockList, env,
+			w.chain, w.chainConfig, algoConf, w.blockList, env,
 			w.config.BuilderTxSigningKey, interrupt,
 		)
 


### PR DESCRIPTION
## 📝 Summary

- Add support for `--miner.price_cutoff_percent`, used when `--miner.algotype=greedy-buckets` to support dynamic bucket sizes for block building algorithm
  - Example: Setting `--miner.price_cutoff_percent` to `0` and `--miner.algotype=greedy-buckets` is comparable to "total profit" block building algorithm, where all transactions are sorted by effective gas price, and then sorted by max profit. 

<!--- A general summary of your changes -->

## 📚 References

<!-- Any interesting external links to documentation, articles, tweets which add value to the PR -->

---

* [x] I have seen and agree to [`CONTRIBUTING.md`](https://github.com/flashbots/builder/blob/main/CONTRIBUTING.md)
