### PR TITLE
Init BuilderRateLimitResubmitInterval builder config param from command line flag.

### DIFF
--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -1680,6 +1680,7 @@ func SetBuilderConfig(ctx *cli.Context, cfg *builder.Config) {
 	cfg.BuilderRateLimitMaxBurst = ctx.Int(BuilderRateLimitMaxBurst.Name)
 	cfg.BuilderSubmissionOffset = ctx.Duration(BuilderSubmissionOffset.Name)
 	cfg.EnableCancellations = ctx.IsSet(BuilderEnableCancellations.Name)
+	cfg.BuilderRateLimitResubmitInterval = ctx.String(BuilderBlockResubmitInterval.Name)
 }
 
 // SetNodeConfig applies node-related command line flags to the config.


### PR DESCRIPTION
## 📝 Summary

Because of absent initialization --builder.block_resubmit_interval param always ignored and default value is used

## 📚 References


---

* [ x] I have seen and agree to [`CONTRIBUTING.md`](https://github.com/flashbots/builder/blob/main/CONTRIBUTING.md)
