### PR TITLE
[trivial] [Breaking Change] Migrate some miner CLI flags to builder

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,10 @@ $ geth --help
     --builder.bellatrix_fork_version value (default: "0x02000000")
           Bellatrix fork version. [$BUILDER_BELLATRIX_FORK_VERSION]
 
+    --builder.blacklist value     
+          Path to file containing blacklisted addresses, json-encoded list of strings.
+          Builder will ignore transactions that touch mentioned addresses.
+   
     --builder.block_resubmit_interval value (default: "500ms")
           Determines the interval at which builder will resubmit block submissions
           [$FLASHBOTS_BUILDER_RATE_LIMIT_RESUBMIT_INTERVAL]
@@ -123,21 +127,19 @@ $ geth --help
           blocks. For example, if a slot is 12 seconds long, and the offset is 2 seconds,
           the builder will submit blocks at 10 seconds into the slot.
           [$FLASHBOTS_BUILDER_SUBMISSION_OFFSET]
-
-    --builder.validation_blacklist value
-          Path to file containing blacklisted addresses, json-encoded list of strings
-
+   
     --builder.validator_checks     (default: false)
           Enable the validator checks
 
     MINER
 
     --miner.algotype value         (default: "mev-geth")
-          Block building algorithm to use [=mev-geth] (mev-geth, greedy, greedy-buckets)
+          [NOTE: Deprecated, please use builder.algotype instead] Block building algorithm
+          to use [=mev-geth] (mev-geth, greedy, greedy-buckets)
 
-    --miner.blocklist value
-          flashbots - Path to JSON file with list of blocked addresses. Miner will ignore
-          txs that touch mentioned addresses.
+    --miner.blocklist value       
+          [NOTE: Deprecated, please use builder.blacklist] flashbots - Path to JSON file with
+          list of blocked addresses. Miner will ignore txs that touch mentioned addresses.
 
     --miner.extradata value
           Block extra data set by the miner (default = client version)

--- a/README.md
+++ b/README.md
@@ -38,6 +38,9 @@ $ geth --help
     --builder                      (default: false)
           Enable the builder
 
+    --builder.algotype value       (default: "mev-geth")
+          Block building algorithm to use [=mev-geth] (mev-geth, greedy, greedy-buckets)
+   
     --builder.beacon_endpoints value (default: "http://127.0.0.1:5052")
           Comma separated list of beacon endpoints to connect to for beacon chain data
           [$BUILDER_BEACON_ENDPOINTS]
@@ -73,6 +76,15 @@ $ geth --help
 
     --builder.no_bundle_fetcher    (default: false)
           Disable the bundle fetcher
+
+    --builder.price_cutoff_percent value (default: 50)
+          flashbots - The minimum effective gas price threshold used for bucketing
+          transactions by price. For example if the top transaction in a list has an
+          effective gas price of 1000 wei and price_cutoff_percent is 10 (i.e. 10%), then
+          the minimum effective gas price included in the same bucket as the top
+          transaction is (1000 * 10%) = 100 wei.
+          NOTE: This flag is only used when
+          miner.algotype=greedy-buckets [$FLASHBOTS_BUILDER_PRICE_CUTOFF_PERCENT]
 
     --builder.rate_limit_duration value (default: "500ms")
           Determines rate limit of events processed by builder. For example, a value of

--- a/README.md
+++ b/README.md
@@ -183,8 +183,7 @@ See the [metrics docs](https://geth.ethereum.org/docs/monitoring/metrics) for ge
 
 If you want to reject transactions interacting with certain addresses, save the addresses in json file with an array of strings. Deciding whether to use such a list, as well as maintaining it, is your own responsibility.
 
-- for block building, use `--miner.blocklist`
-- for validation, use `--builder.validation_blacklist`
+- for block building and validation, use `--builder.blacklist`
 
 --
 
@@ -234,7 +233,7 @@ Miner is responsible for block creation. Request from the `builder` is routed to
 * `algo_greedy.go` implements logic of the block building. Bundles and transactions are sorted in the order of effective gas price then
   we try to insert everything into to block until gas limit is reached. Failing bundles are reverted during the insertion but txs are not.
 * Builder can filter transactions touching a particular set of addresses.
-  If a bundle or transaction touches one of the addresses it is skipped. (see `--miner.blocklist` flag)
+  If a bundle or transaction touches one of the addresses it is skipped. (see `--builder.blacklist` flag)
 
 ## Bundle Movement
 

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ $ geth --help
           the minimum effective gas price included in the same bucket as the top
           transaction is (1000 * 10%) = 100 wei.
           NOTE: This flag is only used when
-          miner.algotype=greedy-buckets [$FLASHBOTS_BUILDER_PRICE_CUTOFF_PERCENT]
+          builder.algotype=greedy-buckets [$FLASHBOTS_BUILDER_PRICE_CUTOFF_PERCENT]
 
     --builder.rate_limit_duration value (default: "500ms")
           Determines rate limit of events processed by builder. For example, a value of

--- a/cmd/geth/main.go
+++ b/cmd/geth/main.go
@@ -125,6 +125,7 @@ var (
 		utils.MinerNotifyFlag,
 		utils.MinerGasLimitFlag,
 		utils.MinerGasPriceFlag,
+		utils.MinerAlgoTypeFlag,
 		utils.MinerEtherbaseFlag,
 		utils.MinerExtraDataFlag,
 		utils.MinerRecommitIntervalFlag,

--- a/cmd/geth/main.go
+++ b/cmd/geth/main.go
@@ -125,7 +125,6 @@ var (
 		utils.MinerNotifyFlag,
 		utils.MinerGasLimitFlag,
 		utils.MinerGasPriceFlag,
-		utils.MinerAlgoTypeFlag,
 		utils.MinerEtherbaseFlag,
 		utils.MinerExtraDataFlag,
 		utils.MinerRecommitIntervalFlag,
@@ -133,7 +132,6 @@ var (
 		utils.MinerMaxMergedBundlesFlag,
 		utils.MinerBlocklistFileFlag,
 		utils.MinerNewPayloadTimeout,
-		utils.MinerPriceCutoffPercentFlag,
 		utils.NATFlag,
 		utils.NoDiscoverFlag,
 		utils.DiscoveryV5Flag,
@@ -159,6 +157,8 @@ var (
 
 	builderApiFlags = []cli.Flag{
 		utils.BuilderEnabled,
+		utils.BuilderAlgoTypeFlag,
+		utils.BuilderPriceCutoffPercentFlag,
 		utils.BuilderEnableValidatorChecks,
 		utils.BuilderBlockValidationBlacklistSourceFilePath,
 		utils.BuilderEnableLocalRelay,

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -1904,7 +1904,7 @@ func setMiner(ctx *cli.Context, cfg *miner.Config) {
 	if ctx.IsSet(MinerAlgoTypeFlag.Name) {
 		algoType, err := miner.AlgoTypeFlagToEnum(ctx.String(BuilderAlgoTypeFlag.Name))
 		if err != nil {
-			Fatalf("Invalid algo in --builder.algotype: %s", ctx.String(BuilderAlgoTypeFlag.Name))
+			Fatalf("Invalid algo in --miner.algotype: %s", ctx.String(BuilderAlgoTypeFlag.Name))
 		}
 		cfg.AlgoType = algoType
 	}

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -712,7 +712,7 @@ var (
 			"For example if the top transaction in a list has an effective gas price of 1000 wei and price_cutoff_percent " +
 			"is 10 (i.e. 10%), then the minimum effective gas price included in the same bucket as the top transaction " +
 			"is (1000 * 10%) = 100 wei.\n" +
-			"NOTE: This flag is only used when miner.algotype=greedy-buckets",
+			"NOTE: This flag is only used when builder.algotype=greedy-buckets",
 		Value:    ethconfig.Defaults.Miner.PriceCutoffPercent,
 		Category: flags.BuilderCategory,
 		EnvVars:  []string{"FLASHBOTS_BUILDER_PRICE_CUTOFF_PERCENT"},

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -546,12 +546,6 @@ var (
 		Value:    ethconfig.Defaults.Miner.GasPrice,
 		Category: flags.MinerCategory,
 	}
-	MinerAlgoTypeFlag = &cli.StringFlag{
-		Name:     "miner.algotype",
-		Usage:    "Block building algorithm to use [=mev-geth] (mev-geth, greedy, greedy-buckets)",
-		Value:    "mev-geth",
-		Category: flags.MinerCategory,
-	}
 	MinerEtherbaseFlag = &cli.StringFlag{
 		Name:     "miner.etherbase",
 		Usage:    "0x prefixed public address for block mining rewards",
@@ -590,17 +584,6 @@ var (
 		Usage:    "Specify the maximum time allowance for creating a new payload",
 		Value:    ethconfig.Defaults.Miner.NewPayloadTimeout,
 		Category: flags.MinerCategory,
-	}
-	MinerPriceCutoffPercentFlag = &cli.IntFlag{
-		Name: "miner.price_cutoff_percent",
-		Usage: "flashbots - The minimum effective gas price threshold used for bucketing transactions by price. " +
-			"For example if the top transaction in a list has an effective gas price of 1000 wei and price_cutoff_percent " +
-			"is 10 (i.e. 10%), then the minimum effective gas price included in the same bucket as the top transaction " +
-			"is (1000 * 10%) = 100 wei.\n" +
-			"NOTE: This flag is only used when miner.algotype=greedy-buckets",
-		Value:    ethconfig.Defaults.Miner.PriceCutoffPercent,
-		Category: flags.MinerCategory,
-		EnvVars:  []string{"FLASHBOTS_MINER_PRICE_CUTOFF_PERCENT"},
 	}
 
 	// Account settings
@@ -709,6 +692,32 @@ var (
 		Usage:    "Enable the builder",
 		Category: flags.BuilderCategory,
 	}
+
+	// BuilderAlgoTypeFlag replaces MinerAlgoTypeFlag to move away from deprecated miner package
+	// Note: builder.algotype was previously miner.algotype - this flag is still propagated to the miner configuration,
+	// see setMiner in cmd/utils/flags.go
+	BuilderAlgoTypeFlag = &cli.StringFlag{
+		Name:     "builder.algotype",
+		Usage:    "Block building algorithm to use [=mev-geth] (mev-geth, greedy, greedy-buckets)",
+		Value:    "mev-geth",
+		Category: flags.BuilderCategory,
+	}
+
+	// BuilderPriceCutoffPercentFlag replaces MinerPriceCutoffPercentFlag to move away from deprecated miner package
+	// Note: builder.price_cutoff_percent was previously miner.price_cutoff_percent -
+	// this flag is still propagated to the miner configuration, see setMiner in cmd/utils/flags.go
+	BuilderPriceCutoffPercentFlag = &cli.IntFlag{
+		Name: "builder.price_cutoff_percent",
+		Usage: "flashbots - The minimum effective gas price threshold used for bucketing transactions by price. " +
+			"For example if the top transaction in a list has an effective gas price of 1000 wei and price_cutoff_percent " +
+			"is 10 (i.e. 10%), then the minimum effective gas price included in the same bucket as the top transaction " +
+			"is (1000 * 10%) = 100 wei.\n" +
+			"NOTE: This flag is only used when miner.algotype=greedy-buckets",
+		Value:    ethconfig.Defaults.Miner.PriceCutoffPercent,
+		Category: flags.BuilderCategory,
+		EnvVars:  []string{"FLASHBOTS_BUILDER_PRICE_CUTOFF_PERCENT"},
+	}
+
 	BuilderEnableValidatorChecks = &cli.BoolFlag{
 		Name:     "builder.validator_checks",
 		Usage:    "Enable the validator checks",
@@ -1876,10 +1885,10 @@ func setMiner(ctx *cli.Context, cfg *miner.Config) {
 	if ctx.IsSet(MinerGasPriceFlag.Name) {
 		cfg.GasPrice = flags.GlobalBig(ctx, MinerGasPriceFlag.Name)
 	}
-	if ctx.IsSet(MinerAlgoTypeFlag.Name) {
-		algoType, err := miner.AlgoTypeFlagToEnum(ctx.String(MinerAlgoTypeFlag.Name))
+	if ctx.IsSet(BuilderAlgoTypeFlag.Name) {
+		algoType, err := miner.AlgoTypeFlagToEnum(ctx.String(BuilderAlgoTypeFlag.Name))
 		if err != nil {
-			Fatalf("Invalid algo in --miner.algotype: %s", ctx.String(MinerAlgoTypeFlag.Name))
+			Fatalf("Invalid algo in --builder.algotype: %s", ctx.String(BuilderAlgoTypeFlag.Name))
 		}
 		cfg.AlgoType = algoType
 	}
@@ -1906,7 +1915,7 @@ func setMiner(ctx *cli.Context, cfg *miner.Config) {
 		}
 	}
 
-	cfg.PriceCutoffPercent = ctx.Int(MinerPriceCutoffPercentFlag.Name)
+	cfg.PriceCutoffPercent = ctx.Int(BuilderPriceCutoffPercentFlag.Name)
 }
 
 func setRequiredBlocks(ctx *cli.Context, cfg *ethconfig.Config) {

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -732,8 +732,10 @@ var (
 	BuilderBlockValidationBlacklistSourceFilePath = &cli.StringFlag{
 		Name: "builder.blacklist",
 		Usage: "Path to file containing blacklisted addresses, json-encoded list of strings. " +
-			"Builder will ignore transactions that touch mentioned addresses.",
+			"Builder will ignore transactions that touch mentioned addresses. This flag is also used for block validation API.\n" +
+			"NOTE: builder.validation_blacklist is deprecated and will be removed in the future in favor of builder.blacklist",
 		Value:    "",
+		Aliases:  []string{"builder.validation_blacklist"},
 		Category: flags.BuilderCategory,
 	}
 	BuilderEnableLocalRelay = &cli.BoolFlag{


### PR DESCRIPTION
## 📝 Summary

- Copy `--miner.algotype` to `--builder.algotype`
- Move `--miner.price_cutoff_percent` to `--builder.price_cutoff_percent` 
- Both flags still used in miner configuration since migrating configuration is nontrivial 
- This change helps us incrementally move away from miner package which is deprecated. However, it requires discussion with team to see whether we merge this, since it fragments configuration instantiation between builder and miner structs. 
  - This PR may get closed if team decides not worth it 
- **Note**: This is a breaking change

<!--- A general summary of your changes -->

## 📚 References

<!-- Any interesting external links to documentation, articles, tweets which add value to the PR -->

---

* [x] I have seen and agree to [`CONTRIBUTING.md`](https://github.com/flashbots/builder/blob/main/CONTRIBUTING.md)
