### PR TITLE
[trivial] CLI fixes

### DIFF
--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -582,7 +582,6 @@ var (
 	MinerBlocklistFileFlag = &cli.StringFlag{
 		Name:     "miner.blocklist",
 		Usage:    "[NOTE: Deprecated, please use builder.blacklist] flashbots - Path to JSON file with list of blocked addresses. Miner will ignore txs that touch mentioned addresses.",
-		Value:    "",
 		Category: flags.MinerCategory,
 	}
 	MinerNewPayloadTimeout = &cli.DurationFlag{
@@ -705,7 +704,6 @@ var (
 	BuilderAlgoTypeFlag = &cli.StringFlag{
 		Name:     "builder.algotype",
 		Usage:    "Block building algorithm to use [=mev-geth] (mev-geth, greedy, greedy-buckets)",
-		Value:    "mev-geth",
 		Category: flags.BuilderCategory,
 	}
 
@@ -734,7 +732,6 @@ var (
 		Usage: "Path to file containing blacklisted addresses, json-encoded list of strings. " +
 			"Builder will ignore transactions that touch mentioned addresses. This flag is also used for block validation API.\n" +
 			"NOTE: builder.validation_blacklist is deprecated and will be removed in the future in favor of builder.blacklist",
-		Value:    "",
 		Aliases:  []string{"builder.validation_blacklist"},
 		Category: flags.BuilderCategory,
 	}
@@ -1676,7 +1673,9 @@ func SetP2PConfig(ctx *cli.Context, cfg *p2p.Config) {
 
 // SetBuilderConfig applies node-related command line flags to the builder config.
 func SetBuilderConfig(ctx *cli.Context, cfg *builder.Config) {
-	cfg.Enabled = ctx.IsSet(BuilderEnabled.Name)
+	if ctx.IsSet(BuilderEnabled.Name) {
+		cfg.Enabled = ctx.Bool(BuilderEnabled.Name)
+	}
 	cfg.EnableValidatorChecks = ctx.IsSet(BuilderEnableValidatorChecks.Name)
 	cfg.EnableLocalRelay = ctx.IsSet(BuilderEnableLocalRelay.Name)
 	cfg.SlotsInEpoch = ctx.Uint64(BuilderSlotsInEpoch.Name)
@@ -1944,7 +1943,7 @@ func setMiner(ctx *cli.Context, cfg *miner.Config) {
 
 	// NOTE: This flag takes precedence and will overwrite value set by MinerBlocklistFileFlag
 	if ctx.IsSet(BuilderBlockValidationBlacklistSourceFilePath.Name) {
-		bytes, err := os.ReadFile(ctx.String(MinerBlocklistFileFlag.Name))
+		bytes, err := os.ReadFile(ctx.String(BuilderBlockValidationBlacklistSourceFilePath.Name))
 		if err != nil {
 			Fatalf("Failed to read blocklist file: %s", err)
 		}

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -231,7 +231,10 @@ func New(stack *node.Node, config *ethconfig.Config) (*Ethereum, error) {
 	}
 
 	eth.miner = miner.New(eth, &config.Miner, eth.blockchain.Config(), eth.EventMux(), eth.engine, eth.isLocalBlock)
-	eth.miner.SetExtra(makeExtraData(config.Miner.ExtraData))
+	err = eth.miner.SetExtra(makeExtraData(config.Miner.ExtraData))
+	if err != nil {
+		return nil, err
+	}
 
 	eth.APIBackend = &EthAPIBackend{stack.Config().ExtRPCEnabled(), stack.Config().AllowUnprotectedTxs, eth, nil}
 	if eth.APIBackend.allowUnprotectedTxs {


### PR DESCRIPTION
## 📝 Summary

- When `miner.blocklist` was not specified, it still tried to load empty file with the CLI flag, because `Value` was set to `""` 
- When `builder.algotype` was not specified, it still tried to load default value of `mev-geth`, overriding `miner.algotype` if specified
- `SetBuilderConfig` had a bug - `cfg.Enabled` was being set to whether or not `BuilderEnabled` was set. This was leading to incorrect behavior when `--builder=false` was set
- Fix `BuilderBlockValidationBlacklistSourceFilePath` referencing wrong flag for file load
- We weren't checking error when setting extra data for miner 
- This PR fixes above issues
<!--- A general summary of your changes -->

## 📚 References

<!-- Any interesting external links to documentation, articles, tweets which add value to the PR -->

---

* [x] I have seen and agree to [`CONTRIBUTING.md`](https://github.com/flashbots/builder/blob/main/CONTRIBUTING.md)
