### PR TITLE
Pass discard flag to miner from builder, revertible transaction gas used

### DIFF
--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -1964,6 +1964,7 @@ func setMiner(ctx *cli.Context, cfg *miner.Config) {
 		}
 	}
 
+	cfg.DiscardRevertibleTxOnErr = ctx.Bool(BuilderDiscardRevertibleTxOnErr.Name)
 	cfg.PriceCutoffPercent = ctx.Int(BuilderPriceCutoffPercentFlag.Name)
 }
 

--- a/miner/algo_common.go
+++ b/miner/algo_common.go
@@ -341,7 +341,13 @@ func (envDiff *environmentDiff) commitBundle(bundle *types.SimulatedBundle, chDa
 	bundleProfit := coinbaseBalanceDelta
 
 	gasUsedBigInt := new(big.Int).SetUint64(gasUsed)
-	bundleActualEffGP := bundleProfit.Div(bundleProfit, gasUsedBigInt)
+
+	var bundleActualEffGP *big.Int
+	if gasUsed == 0 {
+		bundleActualEffGP = big.NewInt(0)
+	} else {
+		bundleActualEffGP = bundleProfit.Div(bundleProfit, gasUsedBigInt)
+	}
 	bundleSimEffGP := new(big.Int).Set(bundle.MevGasPrice)
 
 	// allow >-1% divergence

--- a/miner/miner.go
+++ b/miner/miner.go
@@ -84,21 +84,22 @@ func AlgoTypeFlagToEnum(algoString string) (AlgoType, error) {
 
 // Config is the configuration parameters of mining.
 type Config struct {
-	Etherbase           common.Address    `toml:",omitempty"` // Public address for block mining rewards (default = first account)
-	Notify              []string          `toml:",omitempty"` // HTTP URL list to be notified of new work packages (only useful in ethash).
-	NotifyFull          bool              `toml:",omitempty"` // Notify with pending block headers instead of work packages
-	ExtraData           hexutil.Bytes     `toml:",omitempty"` // Block extra data set by the miner
-	GasFloor            uint64            // Target gas floor for mined blocks.
-	GasCeil             uint64            // Target gas ceiling for mined blocks.
-	GasPrice            *big.Int          // Minimum gas price for mining a transaction
-	AlgoType            AlgoType          // Algorithm to use for block building
-	Recommit            time.Duration     // The time interval for miner to re-create mining work.
-	Noverify            bool              // Disable remote mining solution verification(only useful in ethash).
-	BuilderTxSigningKey *ecdsa.PrivateKey `toml:",omitempty"` // Signing key of builder coinbase to make transaction to validator
-	MaxMergedBundles    int
-	Blocklist           []common.Address `toml:",omitempty"`
-	NewPayloadTimeout   time.Duration    // The maximum time allowance for creating a new payload
-	PriceCutoffPercent  int              // Effective gas price cutoff % used for bucketing transactions by price (only useful in greedy-buckets AlgoType)
+	Etherbase                common.Address    `toml:",omitempty"` // Public address for block mining rewards (default = first account)
+	Notify                   []string          `toml:",omitempty"` // HTTP URL list to be notified of new work packages (only useful in ethash).
+	NotifyFull               bool              `toml:",omitempty"` // Notify with pending block headers instead of work packages
+	ExtraData                hexutil.Bytes     `toml:",omitempty"` // Block extra data set by the miner
+	GasFloor                 uint64            // Target gas floor for mined blocks.
+	GasCeil                  uint64            // Target gas ceiling for mined blocks.
+	GasPrice                 *big.Int          // Minimum gas price for mining a transaction
+	AlgoType                 AlgoType          // Algorithm to use for block building
+	Recommit                 time.Duration     // The time interval for miner to re-create mining work.
+	Noverify                 bool              // Disable remote mining solution verification(only useful in ethash).
+	BuilderTxSigningKey      *ecdsa.PrivateKey `toml:",omitempty"` // Signing key of builder coinbase to make transaction to validator
+	MaxMergedBundles         int
+	Blocklist                []common.Address `toml:",omitempty"`
+	NewPayloadTimeout        time.Duration    // The maximum time allowance for creating a new payload
+	DiscardRevertibleTxOnErr bool             // Whether to discard revertible transactions on error
+	PriceCutoffPercent       int              // Effective gas price cutoff % used for bucketing transactions by price (only useful in greedy-buckets AlgoType)
 }
 
 // DefaultConfig contains default settings for miner.

--- a/miner/multi_worker.go
+++ b/miner/multi_worker.go
@@ -201,10 +201,9 @@ func newMultiWorkerMevGeth(config *Config, chainConfig *params.ChainConfig, engi
 }
 
 type flashbotsData struct {
-	isFlashbots           bool
-	queue                 chan *task
-	maxMergedBundles      int
-	algoType              AlgoType
-	bundleCache           *BundleCache
-	discardRevertedHashes bool
+	isFlashbots      bool
+	queue            chan *task
+	maxMergedBundles int
+	algoType         AlgoType
+	bundleCache      *BundleCache
 }

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -1409,7 +1409,7 @@ func (w *worker) fillTransactionsAlgoWorker(interrupt *int32, env *environment) 
 		}
 
 		algoConf := &algorithmConfig{
-			DropRevertibleTxOnErr:  w.flashbots.discardRevertedHashes,
+			DropRevertibleTxOnErr:  w.config.DiscardRevertibleTxOnErr,
 			EnforceProfit:          true,
 			ProfitThresholdPercent: defaultProfitThresholdPercent,
 			PriceCutoffPercent:     priceCutoffPercent,
@@ -1426,7 +1426,7 @@ func (w *worker) fillTransactionsAlgoWorker(interrupt *int32, env *environment) 
 		// For default greedy builder, set algorithm configuration to default values,
 		// except DropRevertibleTxOnErr which is passed in from worker config
 		algoConf := &algorithmConfig{
-			DropRevertibleTxOnErr:  w.flashbots.discardRevertedHashes,
+			DropRevertibleTxOnErr:  w.config.DiscardRevertibleTxOnErr,
 			EnforceProfit:          defaultAlgorithmConfig.EnforceProfit,
 			ProfitThresholdPercent: defaultAlgorithmConfig.ProfitThresholdPercent,
 		}


### PR DESCRIPTION
## 📝 Summary

- Miner uses revertible discard transaction flag, updated to pass that in
- When revertible transactions are enabled, there can be bundles with zero transactions in them - this causes there to be a zero value for gas used

<!--- A general summary of your changes -->

## 📚 References

<!-- Any interesting external links to documentation, articles, tweets which add value to the PR -->

---

* [x] I have seen and agree to [`CONTRIBUTING.md`](https://github.com/flashbots/builder/blob/main/CONTRIBUTING.md)
