### PR TITLE
rename validation api flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,9 +140,9 @@ $ geth --help
     --builder.validation_blacklist value
           Path to file containing blacklisted addresses, json-encoded list of strings
           
-    --builder.validation_force_last_tx_payment (default: true)
-          Block validation API will enforce that the last tx in the block is payment to
-          the proposer.
+    --builder.validation_use_balance_diff (default: false)
+          Block validation API will use fee recipient balance difference for profit
+          calculation.
    
     --builder.validator_checks     (default: false)
           Enable the validator checks

--- a/builder/config.go
+++ b/builder/config.go
@@ -21,7 +21,7 @@ type Config struct {
 	RemoteRelayEndpoint              string        `toml:",omitempty"`
 	SecondaryRemoteRelayEndpoints    []string      `toml:",omitempty"`
 	ValidationBlocklist              string        `toml:",omitempty"`
-	ValidationForceLastTxPayment     bool          `toml:",omitempty"`
+	ValidationUseCoinbaseDiff        bool          `toml:",omitempty"`
 	BuilderRateLimitDuration         string        `toml:",omitempty"`
 	BuilderRateLimitMaxBurst         int           `toml:",omitempty"`
 	BuilderRateLimitResubmitInterval string        `toml:",omitempty"`
@@ -50,7 +50,7 @@ var DefaultConfig = Config{
 	RemoteRelayEndpoint:           "",
 	SecondaryRemoteRelayEndpoints: nil,
 	ValidationBlocklist:           "",
-	ValidationForceLastTxPayment:  true,
+	ValidationUseCoinbaseDiff:     false,
 	BuilderRateLimitDuration:      RateLimitIntervalDefault.String(),
 	BuilderRateLimitMaxBurst:      RateLimitBurstDefault,
 	DiscardRevertibleTxOnErr:      false,

--- a/builder/service.go
+++ b/builder/service.go
@@ -214,7 +214,7 @@ func Register(stack *node.Node, backend *eth.Ethereum, cfg *Config) error {
 				return fmt.Errorf("failed to load validation blocklist %w", err)
 			}
 		}
-		validator = blockvalidation.NewBlockValidationAPI(backend, accessVerifier, cfg.ValidationForceLastTxPayment)
+		validator = blockvalidation.NewBlockValidationAPI(backend, accessVerifier, cfg.ValidationUseCoinbaseDiff)
 	}
 
 	// Set up builder rate limiter based on environment variables or CLI flags.

--- a/cmd/geth/config.go
+++ b/cmd/geth/config.go
@@ -177,8 +177,8 @@ func makeFullNode(ctx *cli.Context) (*node.Node, ethapi.Backend) {
 	if ctx.IsSet(utils.BuilderBlockValidationBlacklistSourceFilePath.Name) {
 		bvConfig.BlacklistSourceFilePath = ctx.String(utils.BuilderBlockValidationBlacklistSourceFilePath.Name)
 	}
-	if ctx.IsSet(utils.BuilderBlockValidationForceLastTxPayment.Name) {
-		bvConfig.ForceLastTxPayment = ctx.Bool(utils.BuilderBlockValidationForceLastTxPayment.Name)
+	if ctx.IsSet(utils.BuilderBlockValidationUseBalanceDiff.Name) {
+		bvConfig.UseBalanceDiffProfit = ctx.Bool(utils.BuilderBlockValidationUseBalanceDiff.Name)
 	}
 
 	if err := blockvalidationapi.Register(stack, eth, bvConfig); err != nil {

--- a/cmd/geth/main.go
+++ b/cmd/geth/main.go
@@ -162,7 +162,7 @@ var (
 		utils.BuilderPriceCutoffPercentFlag,
 		utils.BuilderEnableValidatorChecks,
 		utils.BuilderBlockValidationBlacklistSourceFilePath,
-		utils.BuilderBlockValidationForceLastTxPayment,
+		utils.BuilderBlockValidationUseBalanceDiff,
 		utils.BuilderEnableLocalRelay,
 		utils.BuilderSecondsInSlot,
 		utils.BuilderSlotsInEpoch,

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -735,10 +735,10 @@ var (
 		Aliases:  []string{"builder.validation_blacklist"},
 		Category: flags.BuilderCategory,
 	}
-	BuilderBlockValidationForceLastTxPayment = &cli.BoolFlag{
-		Name:     "builder.validation_force_last_tx_payment",
-		Usage:    "Block validation API will enforce that the last tx in the block is payment to the proposer.",
-		Value:    true,
+	BuilderBlockValidationUseBalanceDiff = &cli.BoolFlag{
+		Name:     "builder.validation_use_balance_diff",
+		Usage:    "Block validation API will use fee recipient balance difference for profit calculation.",
+		Value:    false,
 		Category: flags.BuilderCategory,
 	}
 	BuilderEnableLocalRelay = &cli.BoolFlag{
@@ -1717,7 +1717,7 @@ func SetBuilderConfig(ctx *cli.Context, cfg *builder.Config) {
 	if ctx.IsSet(BuilderBlockValidationBlacklistSourceFilePath.Name) {
 		cfg.ValidationBlocklist = ctx.String(BuilderBlockValidationBlacklistSourceFilePath.Name)
 	}
-	cfg.ValidationForceLastTxPayment = ctx.Bool(BuilderBlockValidationForceLastTxPayment.Name)
+	cfg.ValidationUseCoinbaseDiff = ctx.Bool(BuilderBlockValidationUseBalanceDiff.Name)
 	cfg.BuilderRateLimitDuration = ctx.String(BuilderRateLimitDuration.Name)
 	cfg.BuilderRateLimitMaxBurst = ctx.Int(BuilderRateLimitMaxBurst.Name)
 	cfg.BuilderSubmissionOffset = ctx.Duration(BuilderSubmissionOffset.Name)

--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -2496,9 +2496,9 @@ func (bc *BlockChain) SetBlockValidatorAndProcessorForTesting(v Validator, p Pro
 
 // ValidatePayload validates the payload of the block.
 // It returns nil if the payload is valid, otherwise it returns an error.
-//   - `forceLastTxPayment` if set to true, proposer payment is assumed to be in the last transaction of the block
+//   - `useBalanceDiffProfit` if set to false, proposer payment is assumed to be in the last transaction of the block
 //     otherwise we use proposer balance changes after the block to calculate proposer payment (see details in the code)
-func (bc *BlockChain) ValidatePayload(block *types.Block, feeRecipient common.Address, expectedProfit *big.Int, registeredGasLimit uint64, vmConfig vm.Config, forceLastTxPayment bool) error {
+func (bc *BlockChain) ValidatePayload(block *types.Block, feeRecipient common.Address, expectedProfit *big.Int, registeredGasLimit uint64, vmConfig vm.Config, useBalanceDiffProfit bool) error {
 	header := block.Header()
 	if err := bc.engine.VerifyHeader(bc, header, true); err != nil {
 		return err
@@ -2565,7 +2565,7 @@ func (bc *BlockChain) ValidatePayload(block *types.Block, feeRecipient common.Ad
 
 	// Validate proposer payment
 
-	if !forceLastTxPayment {
+	if useBalanceDiffProfit {
 		if feeRecipientBalanceDelta.Cmp(expectedProfit) >= 0 {
 			if feeRecipientBalanceDelta.Cmp(expectedProfit) > 0 {
 				log.Warn("builder claimed profit is lower than calculated profit", "expected", expectedProfit, "actual", feeRecipientBalanceDelta)

--- a/eth/block-validation/api.go
+++ b/eth/block-validation/api.go
@@ -88,8 +88,8 @@ func NewAccessVerifierFromFile(path string) (*AccessVerifier, error) {
 
 type BlockValidationConfig struct {
 	BlacklistSourceFilePath string
-	// If set to true, proposer payment is assumed to be in the last transaction of the block.
-	ForceLastTxPayment bool
+	// If set to true, proposer payment is calculated as a balance difference of the fee recipient.
+	UseBalanceDiffProfit bool
 }
 
 // Register adds catalyst APIs to the full node.
@@ -106,7 +106,7 @@ func Register(stack *node.Node, backend *eth.Ethereum, cfg BlockValidationConfig
 	stack.RegisterAPIs([]rpc.API{
 		{
 			Namespace: "flashbots",
-			Service:   NewBlockValidationAPI(backend, accessVerifier, cfg.ForceLastTxPayment),
+			Service:   NewBlockValidationAPI(backend, accessVerifier, cfg.UseBalanceDiffProfit),
 		},
 	})
 	return nil
@@ -115,17 +115,17 @@ func Register(stack *node.Node, backend *eth.Ethereum, cfg BlockValidationConfig
 type BlockValidationAPI struct {
 	eth            *eth.Ethereum
 	accessVerifier *AccessVerifier
-	// If set to true, proposer payment is assumed to be in the last transaction of the block.
-	forceLastTxPayment bool
+	// If set to true, proposer payment is calculated as a balance difference of the fee recipient.
+	useBalanceDiffProfit bool
 }
 
 // NewConsensusAPI creates a new consensus api for the given backend.
 // The underlying blockchain needs to have a valid terminal total difficulty set.
-func NewBlockValidationAPI(eth *eth.Ethereum, accessVerifier *AccessVerifier, forceLastTxPayment bool) *BlockValidationAPI {
+func NewBlockValidationAPI(eth *eth.Ethereum, accessVerifier *AccessVerifier, useBalanceDiffProfit bool) *BlockValidationAPI {
 	return &BlockValidationAPI{
-		eth:                eth,
-		accessVerifier:     accessVerifier,
-		forceLastTxPayment: forceLastTxPayment,
+		eth:                  eth,
+		accessVerifier:       accessVerifier,
+		useBalanceDiffProfit: useBalanceDiffProfit,
 	}
 }
 
@@ -185,7 +185,7 @@ func (api *BlockValidationAPI) ValidateBuilderSubmissionV1(params *BuilderBlockV
 		vmconfig = vm.Config{Tracer: tracer, Debug: true}
 	}
 
-	err = api.eth.BlockChain().ValidatePayload(block, feeRecipient, expectedProfit, params.RegisteredGasLimit, vmconfig, api.forceLastTxPayment)
+	err = api.eth.BlockChain().ValidatePayload(block, feeRecipient, expectedProfit, params.RegisteredGasLimit, vmconfig, api.useBalanceDiffProfit)
 	if err != nil {
 		log.Error("invalid payload", "hash", payload.BlockHash.String(), "number", payload.BlockNumber, "parentHash", payload.ParentHash.String(), "err", err)
 		return err
@@ -277,7 +277,7 @@ func (api *BlockValidationAPI) ValidateBuilderSubmissionV2(params *BuilderBlockV
 		vmconfig = vm.Config{Tracer: tracer, Debug: true}
 	}
 
-	err = api.eth.BlockChain().ValidatePayload(block, feeRecipient, expectedProfit, params.RegisteredGasLimit, vmconfig, api.forceLastTxPayment)
+	err = api.eth.BlockChain().ValidatePayload(block, feeRecipient, expectedProfit, params.RegisteredGasLimit, vmconfig, api.useBalanceDiffProfit)
 	if err != nil {
 		log.Error("invalid payload", "hash", payload.BlockHash.String(), "number", payload.BlockNumber, "parentHash", payload.ParentHash.String(), "err", err)
 		return err

--- a/eth/block-validation/api_test.go
+++ b/eth/block-validation/api_test.go
@@ -69,7 +69,7 @@ func TestValidateBuilderSubmissionV1(t *testing.T) {
 	ethservice.Merger().ReachTTD()
 	defer n.Close()
 
-	api := NewBlockValidationAPI(ethservice, nil, false)
+	api := NewBlockValidationAPI(ethservice, nil, true)
 	parent := preMergeBlocks[len(preMergeBlocks)-1]
 
 	api.eth.APIBackend.Miner().SetEtherbase(testValidatorAddr)
@@ -179,7 +179,7 @@ func TestValidateBuilderSubmissionV2(t *testing.T) {
 	ethservice.Merger().ReachTTD()
 	defer n.Close()
 
-	api := NewBlockValidationAPI(ethservice, nil, false)
+	api := NewBlockValidationAPI(ethservice, nil, true)
 	parent := preMergeBlocks[len(preMergeBlocks)-1]
 
 	api.eth.APIBackend.Miner().SetEtherbase(testBuilderAddr)
@@ -623,7 +623,7 @@ func TestValidateBuilderSubmissionV2_CoinbasePaymentDefault(t *testing.T) {
 	ethservice.Merger().ReachTTD()
 	defer n.Close()
 
-	api := NewBlockValidationAPI(ethservice, nil, false)
+	api := NewBlockValidationAPI(ethservice, nil, true)
 
 	baseFee := misc.CalcBaseFee(ethservice.BlockChain().Config(), lastBlock.Header())
 	txs := make(types.Transactions, 0)
@@ -735,8 +735,8 @@ func TestValidateBuilderSubmissionV2_Blocklist(t *testing.T) {
 		},
 	}
 
-	apiWithBlock := NewBlockValidationAPI(ethservice, accessVerifier, false)
-	apiNoBlock := NewBlockValidationAPI(ethservice, nil, false)
+	apiWithBlock := NewBlockValidationAPI(ethservice, accessVerifier, true)
+	apiNoBlock := NewBlockValidationAPI(ethservice, nil, true)
 
 	baseFee := misc.CalcBaseFee(ethservice.BlockChain().Config(), lastBlock.Header())
 	blockedTxs := make(types.Transactions, 0)


### PR DESCRIPTION
## 📝 Summary

Renames flag

`--builder.validation_force_last_tx_payment (default: true)`

to 

`--builder.validation_use_balance_diff (default: false)`


## 📚 References

<!-- Any interesting external links to documentation, articles, tweets which add value to the PR -->

---

* [x] I have seen and agree to [`CONTRIBUTING.md`](https://github.com/flashbots/builder/blob/main/CONTRIBUTING.md)
