### PR TITLE
support for arm64 image and fix for latest tag in release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,7 +37,7 @@ jobs:
             type=sha
             type=pep440,pattern={{version}}
             type=pep440,pattern={{major}}.{{minor}}
-            type=raw,value=latest,enable=${{ !contains(env.RELEASE_VERSION, '-') }}
+            type=raw,value=latest
 
       - name: Login to DockerHub
         uses: docker/login-action@v2
@@ -52,7 +52,7 @@ jobs:
           push: true
           build-args: |
             VERSION=${{ env.RELEASE_VERSION }}
-          platforms: linux/amd64, linux/arm64
+          platforms: linux/amd64,linux/arm64
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,7 +52,7 @@ jobs:
           push: true
           build-args: |
             VERSION=${{ env.RELEASE_VERSION }}
-          platforms: linux/amd64
+          platforms: linux/amd64, linux/arm64
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
 


### PR DESCRIPTION
## 📝 Summary

Pushes an `arm64` image and `:latest` during release.  

## 📚 References

Fixes https://github.com/flashbots/builder/issues/107 and https://github.com/flashbots/builder/issues/105

---

* [x] I have seen and agree to [`CONTRIBUTING.md`](https://github.com/flashbots/builder/blob/main/CONTRIBUTING.md)
