### PR TITLE
Feature: overwrite request gas limits and return new values to relay

### DIFF
--- a/builder/builder.go
+++ b/builder/builder.go
@@ -319,10 +319,14 @@ func (b *Builder) submitCapellaBlock(block *types.Block, blockValue *big.Int, or
 	}
 
 	if b.dryRun {
-		err = b.validator.ValidateBuilderSubmissionV2(&blockvalidation.BuilderBlockValidationRequestV2{SubmitBlockRequest: blockSubmitReq, RegisteredGasLimit: vd.GasLimit})
+		resp, err := b.validator.ValidateBuilderSubmissionV2(&blockvalidation.BuilderBlockValidationRequestV2{SubmitBlockRequest: blockSubmitReq, RegisteredGasLimit: vd.GasLimit})
 		if err != nil {
 			log.Error("could not validate block for capella", "err", err)
 		}
+		if resp.NewGasLimit != payload.GasLimit {
+			log.Error("gas limit adjusted needed for capella", "gasLimit", payload.GasLimit, "newGasLimit", resp.NewGasLimit)
+		}
+
 	} else {
 		go b.ds.ConsumeBuiltBlock(block, blockValue, ordersClosedAt, sealedAt, commitedBundles, allBundles, usedSbundles, &blockBidMsg)
 		err = b.relay.SubmitBlockCapella(&blockSubmitReq, vd)

--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -2494,6 +2494,27 @@ func (bc *BlockChain) SetBlockValidatorAndProcessorForTesting(v Validator, p Pro
 	bc.processor = p
 }
 
+//
+func (bc *BlockChain) AdjustedGasLimit(block *types.Block, registeredGasLimit uint64) (uint64, error) {
+	header := block.Header()
+	if err := bc.engine.VerifyHeader(bc, header, true); err != nil {
+		return 0, err
+	}
+
+	current := bc.CurrentBlock()
+	reorg, err := bc.forker.ReorgNeeded(current, header)
+	if err == nil && reorg {
+		return 0, errors.New("block requires a reorg")
+	}
+
+	parent := bc.GetHeader(block.ParentHash(), block.NumberU64()-1)
+	if parent == nil {
+		return 0, errors.New("parent not found")
+	}
+
+	return utils.CalcGasLimit(parent.GasLimit, registeredGasLimit), nil
+}
+
 // ValidatePayload validates the payload of the block.
 // It returns nil if the payload is valid, otherwise it returns an error.
 //   - `useBalanceDiffProfit` if set to false, proposer payment is assumed to be in the last transaction of the block

--- a/eth/block-validation/api.go
+++ b/eth/block-validation/api.go
@@ -228,32 +228,38 @@ func (r *BuilderBlockValidationRequestV2) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
-func (api *BlockValidationAPI) ValidateBuilderSubmissionV2(params *BuilderBlockValidationRequestV2) error {
+type BuilderBlockValidationResponseV2 struct {
+	NewGasLimit uint64 `json:"new_gas_limit,string"`
+	NewBlockHash string `json:"new_block_hash"`
+}
+
+func (api *BlockValidationAPI) ValidateBuilderSubmissionV2(params *BuilderBlockValidationRequestV2) (*BuilderBlockValidationResponseV2, error) {
 	// TODO: fuzztest, make sure the validation is sound
 	// TODO: handle context!
 	if params.ExecutionPayload == nil {
-		return errors.New("nil execution payload")
+		return nil, errors.New("nil execution payload")
 	}
+
 	payload := params.ExecutionPayload
 	block, err := engine.ExecutionPayloadV2ToBlock(payload)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	if params.Message.ParentHash != phase0.Hash32(block.ParentHash()) {
-		return fmt.Errorf("incorrect ParentHash %s, expected %s", params.Message.ParentHash.String(), block.ParentHash().String())
+		return nil, fmt.Errorf("incorrect ParentHash %s, expected %s", params.Message.ParentHash.String(), block.ParentHash().String())
 	}
 
 	if params.Message.BlockHash != phase0.Hash32(block.Hash()) {
-		return fmt.Errorf("incorrect BlockHash %s, expected %s", params.Message.BlockHash.String(), block.Hash().String())
+		return nil, fmt.Errorf("incorrect BlockHash %s, expected %s", params.Message.BlockHash.String(), block.Hash().String())
 	}
 
 	if params.Message.GasLimit != block.GasLimit() {
-		return fmt.Errorf("incorrect GasLimit %d, expected %d", params.Message.GasLimit, block.GasLimit())
+		return nil, fmt.Errorf("incorrect GasLimit %d, expected %d", params.Message.GasLimit, block.GasLimit())
 	}
 
 	if params.Message.GasUsed != block.GasUsed() {
-		return fmt.Errorf("incorrect GasUsed %d, expected %d", params.Message.GasUsed, block.GasUsed())
+		return nil, fmt.Errorf("incorrect GasUsed %d, expected %d", params.Message.GasUsed, block.GasUsed())
 	}
 
 	feeRecipient := common.BytesToAddress(params.Message.ProposerFeeRecipient[:])
@@ -263,13 +269,13 @@ func (api *BlockValidationAPI) ValidateBuilderSubmissionV2(params *BuilderBlockV
 	var tracer *logger.AccessListTracer = nil
 	if api.accessVerifier != nil {
 		if err := api.accessVerifier.isBlacklisted(block.Coinbase()); err != nil {
-			return err
+			return nil, err
 		}
 		if err := api.accessVerifier.isBlacklisted(feeRecipient); err != nil {
-			return err
+			return nil, err
 		}
 		if err := api.accessVerifier.verifyTransactions(types.LatestSigner(api.eth.BlockChain().Config()), block.Transactions()); err != nil {
-			return err
+			return nil, err
 		}
 		isPostMerge := true // the call is PoS-native
 		precompiles := vm.ActivePrecompiles(api.eth.APIBackend.ChainConfig().Rules(new(big.Int).SetUint64(params.ExecutionPayload.BlockNumber), isPostMerge, params.ExecutionPayload.Timestamp))
@@ -277,18 +283,41 @@ func (api *BlockValidationAPI) ValidateBuilderSubmissionV2(params *BuilderBlockV
 		vmconfig = vm.Config{Tracer: tracer, Debug: true}
 	}
 
-	err = api.eth.BlockChain().ValidatePayload(block, feeRecipient, expectedProfit, params.RegisteredGasLimit, vmconfig, api.useBalanceDiffProfit)
+	bc := api.eth.BlockChain()
+
+	// After validation of the message, we modify the block's gas limit
+	adjustedGasLimit, err := bc.AdjustedGasLimit(block, params.RegisteredGasLimit)
+	if err != nil {
+		return nil, err
+	}
+	// If the gas limit was adjusted, we need to regenerate the block
+	// as mutating them is generally unsupported
+	if payload.GasLimit != adjustedGasLimit {
+		payload.GasLimit = adjustedGasLimit
+		block, err = engine.ExecutionPayloadV2ToBlock(payload)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+
+	err = bc.ValidatePayload(block, feeRecipient, expectedProfit, params.RegisteredGasLimit, vmconfig, api.useBalanceDiffProfit)
 	if err != nil {
 		log.Error("invalid payload", "hash", payload.BlockHash.String(), "number", payload.BlockNumber, "parentHash", payload.ParentHash.String(), "err", err)
-		return err
+		return nil, err
 	}
 
 	if api.accessVerifier != nil && tracer != nil {
 		if err := api.accessVerifier.verifyTraces(tracer); err != nil {
-			return err
+			return nil, err
 		}
 	}
 
 	log.Info("validated block", "hash", block.Hash(), "number", block.NumberU64(), "parentHash", block.ParentHash())
-	return nil
+
+	return &BuilderBlockValidationResponseV2{
+		NewGasLimit: block.GasLimit(),
+		NewBlockHash: block.Hash().String(),
+	}, nil
 }
+

--- a/eth/block-validation/api.go
+++ b/eth/block-validation/api.go
@@ -300,7 +300,6 @@ func (api *BlockValidationAPI) ValidateBuilderSubmissionV2(params *BuilderBlockV
 		}
 	}
 
-
 	err = bc.ValidatePayload(block, feeRecipient, expectedProfit, params.RegisteredGasLimit, vmconfig, api.useBalanceDiffProfit)
 	if err != nil {
 		log.Error("invalid payload", "hash", payload.BlockHash.String(), "number", payload.BlockNumber, "parentHash", payload.ParentHash.String(), "err", err)

--- a/eth/block-validation/api_test.go
+++ b/eth/block-validation/api_test.go
@@ -256,8 +256,9 @@ func TestValidateBuilderSubmissionV2(t *testing.T) {
 	blockRequest.ExecutionPayload.GasLimit += 1
 	updatePayloadHashV2(t, blockRequest)
 
-	_, err = api.ValidateBuilderSubmissionV2(blockRequest)
-	require.ErrorContains(t, err, "incorrect gas limit set")
+	// // Test removed as the API now overwrites the gas limit
+	// _, err = api.ValidateBuilderSubmissionV2(blockRequest)
+	// require.ErrorContains(t, err, "incorrect gas limit set")
 
 	blockRequest.Message.GasLimit -= 1
 	blockRequest.ExecutionPayload.GasLimit -= 1


### PR DESCRIPTION
## 📝 Summary

Modifies the v2 endpoint to overwrite gaslimit during simulation, and to return the overwritten values to the relay client

This allows the block-validation logic in the API to adjust the gaslimit set by the block builder in order to achieve specific gas targets specified by the relay api service.

## 📚 References

This is in support of https://github.com/flashbots/mev-boost-relay/pull/519


---

* [x] I have seen and agree to [`CONTRIBUTING.md`](https://github.com/flashbots/builder/blob/main/CONTRIBUTING.md)
