### PR TITLE
Correct estimation of timestamp in eth_callBundle

### DIFF
--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -2252,7 +2252,7 @@ func (s *BundleAPI) CallBundle(ctx context.Context, args CallBundleArgs) (map[st
 	}
 	blockNumber := big.NewInt(int64(args.BlockNumber))
 
-	timestamp := parent.Time + 1
+	timestamp := parent.Time + 12
 	if args.Timestamp != nil {
 		timestamp = *args.Timestamp
 	}


### PR DESCRIPTION
Before we used parent block timestamp + 1 and this breaks simulation of bundles that check that timestamp of the next target block is what is expected.

## 📝 Summary

<!--- A general summary of your changes -->

## 📚 References

<!-- Any interesting external links to documentation, articles, tweets which add value to the PR -->

---

* [x] I have seen and agree to [`CONTRIBUTING.md`](https://github.com/flashbots/builder/blob/main/CONTRIBUTING.md)
