### PR TITLE
Fix null pointer dereference in GetHeader() in LocalRelay

### DIFF
--- a/builder/local_relay.go
+++ b/builder/local_relay.go
@@ -273,7 +273,12 @@ func (r *LocalRelay) handleGetHeader(w http.ResponseWriter, req *http.Request) {
 	profit := r.profit
 	r.bestDataLock.Unlock()
 
-	if bestHeader == nil || bestHeader.ParentHash.String() != parentHashHex {
+	if bestHeader == nil {
+		respondError(w, http.StatusBadRequest, "no headers")
+		return
+	}
+
+	if bestHeader.ParentHash.String() != parentHashHex {
 		respondError(w, http.StatusBadRequest, "unknown payload")
 		return
 	}


### PR DESCRIPTION
## 📝 Summary

If bestHeader is nil, bestHeader.ParentHash.String() causes null pointer dereference

* [x] I have seen and agree to [`CONTRIBUTING.md`](https://github.com/flashbots/builder/blob/main/CONTRIBUTING.md)
