### PR TITLE
Fix typos

### DIFF
--- a/cmd/evm/README.md
+++ b/cmd/evm/README.md
@@ -342,7 +342,7 @@ To make `t8n` apply these, the following inputs are required:
   - For ethash, it is `5000000000000000000` `wei`,
   - If this is not defined, mining rewards are not applied,
   - A value of `0` is valid, and causes accounts to be 'touched'.
-- For each ommer, the tool needs to be given an `addres\` and a `delta`. This
+- For each ommer, the tool needs to be given an `address\` and a `delta`. This
   is done via the `ommers` field in `env`.
 
 Note: the tool does not verify that e.g. the normal uncle rules apply,

--- a/cmd/evm/testdata/5/readme.md
+++ b/cmd/evm/testdata/5/readme.md
@@ -1,1 +1,1 @@
-These files examplify a transition where there are no transcations, two ommers, at block `N-1` (delta 1) and `N-2` (delta 2).
+These files examplify a transition where there are no transactions, two ommers, at block `N-1` (delta 1) and `N-2` (delta 2).

--- a/cmd/evm/testdata/8/readme.md
+++ b/cmd/evm/testdata/8/readme.md
@@ -7,7 +7,7 @@ This test contains testcases for EIP-2930, which uses transactions with access l
 The alloc portion contains one contract (`0x000000000000000000000000000000000000aaaa`), containing the 
 following code: `0x5854505854`: `PC ;SLOAD; POP; PC; SLOAD`.
 
-Essentialy, this contract does `SLOAD(0)` and `SLOAD(3)`.
+Essentially, this contract does `SLOAD(0)` and `SLOAD(3)`.
 
 The alloc also contains some funds on `0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b`. 
 

--- a/cmd/evm/testdata/9/readme.md
+++ b/cmd/evm/testdata/9/readme.md
@@ -7,7 +7,7 @@ This test contains testcases for EIP-1559, which uses an new transaction type an
 The alloc portion contains one contract (`0x000000000000000000000000000000000000aaaa`), containing the 
 following code: `0x58585454`: `PC; PC; SLOAD; SLOAD`.
 
-Essentialy, this contract does `SLOAD(0)` and `SLOAD(1)`.
+Essentially, this contract does `SLOAD(0)` and `SLOAD(1)`.
 
 The alloc also contains some funds on `0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b`. 
 

--- a/cmd/evm/transition-test.sh
+++ b/cmd/evm/transition-test.sh
@@ -280,7 +280,7 @@ To make `t8n` apply these, the following inputs are required:
   - For ethash, it is `5000000000000000000` `wei`,
   - If this is not defined, mining rewards are not applied,
   - A value of `0` is valid, and causes accounts to be 'touched'.
-- For each ommer, the tool needs to be given an `addres\` and a `delta`. This
+- For each ommer, the tool needs to be given an `address\` and a `delta`. This
   is done via the `ommers` field in `env`.
 
 Note: the tool does not verify that e.g. the normal uncle rules apply,


### PR DESCRIPTION
Fix typos in `cmd`