### PR TITLE
fix maxCount handling in loop

### DIFF
--- a/eth/catalyst/simulated_beacon.go
+++ b/eth/catalyst/simulated_beacon.go
@@ -60,7 +60,7 @@ func (w *withdrawalQueue) gatherPending(maxCount int) []*types.Withdrawal {
 		case withdrawal := <-w.pending:
 			withdrawals = append(withdrawals, withdrawal)
 			if len(withdrawals) == maxCount {
-				break
+				return withdrawals
 			}
 		default:
 			return withdrawals


### PR DESCRIPTION
## 📝 Summary

Fixed bug - withdrawals length not limited by maxCount, because of wrong break usage

---

* [v] I have seen and agree to [`CONTRIBUTING.md`](https://github.com/flashbots/builder/blob/main/CONTRIBUTING.md)
