### PR TITLE
Update CI to use go1.22

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v3
         with:
-          go-version: ^1.20
+          go-version: ^1.22
         id: go
 
       - name: Check out code into the Go module directory
@@ -44,7 +44,7 @@ jobs:
     - name: Set up Go 1.x
       uses: actions/setup-go@v3
       with:
-        go-version: ^1.20
+        go-version: ^1.22
       id: go
 
     - name: Check out code into the Go module directory
@@ -65,7 +65,7 @@ jobs:
     - name: Set up Go 1.x
       uses: actions/setup-go@v3
       with:
-        go-version: ^1.20
+        go-version: ^1.22
       id: go
 
     - name: Use Node.js 12.x


### PR DESCRIPTION
## 📝 Summary

With the 1.22 release of Go, 1.20 is now at EOL.  This PR updates CI to use 1.22.

## 📚 References

https://go.dev/blog/go1.22

---

* [x] I have seen and agree to [`CONTRIBUTING.md`](https://github.com/flashbots/builder/blob/main/CONTRIBUTING.md)
