### PR TITLE
Exclude CL withdrawals from profit calculation

### DIFF
--- a/builder/config.go
+++ b/builder/config.go
@@ -22,6 +22,7 @@ type Config struct {
 	SecondaryRemoteRelayEndpoints    []string      `toml:",omitempty"`
 	ValidationBlocklist              string        `toml:",omitempty"`
 	ValidationUseCoinbaseDiff        bool          `toml:",omitempty"`
+	ValidationExcludeWithdrawals     bool          `toml:",omitempty"`
 	BuilderRateLimitDuration         string        `toml:",omitempty"`
 	BuilderRateLimitMaxBurst         int           `toml:",omitempty"`
 	BuilderRateLimitResubmitInterval string        `toml:",omitempty"`
@@ -52,6 +53,7 @@ var DefaultConfig = Config{
 	SecondaryRemoteRelayEndpoints: nil,
 	ValidationBlocklist:           "",
 	ValidationUseCoinbaseDiff:     false,
+	ValidationExcludeWithdrawals:  false,
 	BuilderRateLimitDuration:      RateLimitIntervalDefault.String(),
 	BuilderRateLimitMaxBurst:      RateLimitBurstDefault,
 	DiscardRevertibleTxOnErr:      false,

--- a/builder/service.go
+++ b/builder/service.go
@@ -214,7 +214,7 @@ func Register(stack *node.Node, backend *eth.Ethereum, cfg *Config) error {
 				return fmt.Errorf("failed to load validation blocklist %w", err)
 			}
 		}
-		validator = blockvalidation.NewBlockValidationAPI(backend, accessVerifier, cfg.ValidationUseCoinbaseDiff)
+		validator = blockvalidation.NewBlockValidationAPI(backend, accessVerifier, cfg.ValidationUseCoinbaseDiff, cfg.ValidationExcludeWithdrawals)
 	}
 
 	// Set up builder rate limiter based on environment variables or CLI flags.

--- a/cmd/geth/config.go
+++ b/cmd/geth/config.go
@@ -180,6 +180,9 @@ func makeFullNode(ctx *cli.Context) (*node.Node, ethapi.Backend) {
 	if ctx.IsSet(utils.BuilderBlockValidationUseBalanceDiff.Name) {
 		bvConfig.UseBalanceDiffProfit = ctx.Bool(utils.BuilderBlockValidationUseBalanceDiff.Name)
 	}
+	if ctx.IsSet(utils.BuilderBlockValidationExcludeWithdrawals.Name) {
+		bvConfig.ExcludeWithdrawals = ctx.Bool(utils.BuilderBlockValidationExcludeWithdrawals.Name)
+	}
 
 	if err := blockvalidationapi.Register(stack, eth, bvConfig); err != nil {
 		utils.Fatalf("Failed to register the Block Validation API: %v", err)

--- a/cmd/geth/main.go
+++ b/cmd/geth/main.go
@@ -163,6 +163,7 @@ var (
 		utils.BuilderEnableValidatorChecks,
 		utils.BuilderBlockValidationBlacklistSourceFilePath,
 		utils.BuilderBlockValidationUseBalanceDiff,
+		utils.BuilderBlockValidationExcludeWithdrawals,
 		utils.BuilderEnableLocalRelay,
 		utils.BuilderSecondsInSlot,
 		utils.BuilderSlotsInEpoch,

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -741,6 +741,12 @@ var (
 		Value:    false,
 		Category: flags.BuilderCategory,
 	}
+	BuilderBlockValidationExcludeWithdrawals = &cli.BoolFlag{
+		Name:     "builder.validation_exclude_withdrawals",
+		Usage:    "Block validation API will exclude CL withdrawals to the fee recipient from the balance delta.",
+		Value:    false,
+		Category: flags.BuilderCategory,
+	}
 	BuilderEnableLocalRelay = &cli.BoolFlag{
 		Name:     "builder.local_relay",
 		Usage:    "Enable the local relay",
@@ -1724,6 +1730,7 @@ func SetBuilderConfig(ctx *cli.Context, cfg *builder.Config) {
 		cfg.ValidationBlocklist = ctx.String(BuilderBlockValidationBlacklistSourceFilePath.Name)
 	}
 	cfg.ValidationUseCoinbaseDiff = ctx.Bool(BuilderBlockValidationUseBalanceDiff.Name)
+	cfg.ValidationExcludeWithdrawals = ctx.Bool(BuilderBlockValidationExcludeWithdrawals.Name)
 	cfg.BuilderRateLimitDuration = ctx.String(BuilderRateLimitDuration.Name)
 	cfg.BuilderRateLimitMaxBurst = ctx.Int(BuilderRateLimitMaxBurst.Name)
 	cfg.BuilderSubmissionOffset = ctx.Duration(BuilderSubmissionOffset.Name)

--- a/eth/block-validation/api.go
+++ b/eth/block-validation/api.go
@@ -90,6 +90,8 @@ type BlockValidationConfig struct {
 	BlacklistSourceFilePath string
 	// If set to true, proposer payment is calculated as a balance difference of the fee recipient.
 	UseBalanceDiffProfit bool
+	// If set to true, withdrawals to the fee recipient are excluded from the balance difference.
+	ExcludeWithdrawals bool
 }
 
 // Register adds catalyst APIs to the full node.
@@ -106,7 +108,7 @@ func Register(stack *node.Node, backend *eth.Ethereum, cfg BlockValidationConfig
 	stack.RegisterAPIs([]rpc.API{
 		{
 			Namespace: "flashbots",
-			Service:   NewBlockValidationAPI(backend, accessVerifier, cfg.UseBalanceDiffProfit),
+			Service:   NewBlockValidationAPI(backend, accessVerifier, cfg.UseBalanceDiffProfit, cfg.ExcludeWithdrawals),
 		},
 	})
 	return nil
@@ -117,15 +119,18 @@ type BlockValidationAPI struct {
 	accessVerifier *AccessVerifier
 	// If set to true, proposer payment is calculated as a balance difference of the fee recipient.
 	useBalanceDiffProfit bool
+	// If set to true, withdrawals to the fee recipient are excluded from the balance delta.
+	excludeWithdrawals bool
 }
 
 // NewConsensusAPI creates a new consensus api for the given backend.
 // The underlying blockchain needs to have a valid terminal total difficulty set.
-func NewBlockValidationAPI(eth *eth.Ethereum, accessVerifier *AccessVerifier, useBalanceDiffProfit bool) *BlockValidationAPI {
+func NewBlockValidationAPI(eth *eth.Ethereum, accessVerifier *AccessVerifier, useBalanceDiffProfit, excludeWithdrawals bool) *BlockValidationAPI {
 	return &BlockValidationAPI{
 		eth:                  eth,
 		accessVerifier:       accessVerifier,
 		useBalanceDiffProfit: useBalanceDiffProfit,
+		excludeWithdrawals:   excludeWithdrawals,
 	}
 }
 
@@ -185,7 +190,7 @@ func (api *BlockValidationAPI) ValidateBuilderSubmissionV1(params *BuilderBlockV
 		vmconfig = vm.Config{Tracer: tracer, Debug: true}
 	}
 
-	err = api.eth.BlockChain().ValidatePayload(block, feeRecipient, expectedProfit, params.RegisteredGasLimit, vmconfig, api.useBalanceDiffProfit)
+	err = api.eth.BlockChain().ValidatePayload(block, feeRecipient, expectedProfit, params.RegisteredGasLimit, vmconfig, api.useBalanceDiffProfit, api.excludeWithdrawals)
 	if err != nil {
 		log.Error("invalid payload", "hash", payload.BlockHash.String(), "number", payload.BlockNumber, "parentHash", payload.ParentHash.String(), "err", err)
 		return err
@@ -277,7 +282,7 @@ func (api *BlockValidationAPI) ValidateBuilderSubmissionV2(params *BuilderBlockV
 		vmconfig = vm.Config{Tracer: tracer, Debug: true}
 	}
 
-	err = api.eth.BlockChain().ValidatePayload(block, feeRecipient, expectedProfit, params.RegisteredGasLimit, vmconfig, api.useBalanceDiffProfit)
+	err = api.eth.BlockChain().ValidatePayload(block, feeRecipient, expectedProfit, params.RegisteredGasLimit, vmconfig, api.useBalanceDiffProfit, api.excludeWithdrawals)
 	if err != nil {
 		log.Error("invalid payload", "hash", payload.BlockHash.String(), "number", payload.BlockNumber, "parentHash", payload.ParentHash.String(), "err", err)
 		return err


### PR DESCRIPTION
## 📝 Summary

This adds a new flag `--builder.validation_exclude_withdrawals` that changes how validation API calculates profit of the bid.

If enabled block validation API will exclude CL withdrawals to the fee recipient from the balance delta that is used to calculate profit of the fee recipient.

---

* [x] I have seen and agree to [`CONTRIBUTING.md`](https://github.com/flashbots/builder/blob/main/CONTRIBUTING.md)
