### PR TITLE
expose revert reason and execution error

### DIFF
--- a/internal/ethapi/sbundle_api.go
+++ b/internal/ethapi/sbundle_api.go
@@ -187,6 +187,8 @@ type SimMevBundleResponse struct {
 	RefundableValue hexutil.U256             `json:"refundableValue"`
 	GasUsed         hexutil.Uint64           `json:"gasUsed"`
 	BodyLogs        []core.SimBundleBodyLogs `json:"logs,omitempty"`
+	ExecError       string                   `json:"execError,omitempty"`
+	Revert          hexutil.Bytes            `json:"revert,omitempty"`
 }
 
 type SimMevBundleAuxArgs struct {
@@ -276,6 +278,8 @@ func (api *MevAPI) SimBundle(ctx context.Context, args SendMevBundleArgs, aux Si
 		result.Success = true
 		result.BodyLogs = bundleRes.BodyLogs
 	}
+	result.ExecError = bundleRes.ExecError
+	result.Revert = bundleRes.Revert
 	result.StateBlock = hexutil.Uint64(parentHeader.Number.Uint64())
 	result.MevGasPrice = hexutil.U256(*bundleRes.MevGasPrice)
 	result.Profit = hexutil.U256(*bundleRes.TotalProfit)


### PR DESCRIPTION
## 📝 Summary

For better simulation experience of private transactions

## 📚 References

Response logic similar to `callBundle` (although callBundle returns `revert` as string, which is suboptimal, we return revert data as hexbytes)

---

* [x] I have seen and agree to [`CONTRIBUTING.md`](https://github.com/flashbots/builder/blob/main/CONTRIBUTING.md)
