### PR TITLE
README.md - Added deprecation notice

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,10 @@ This repository contains the historic codebase of the Flashbots geth-based block
 
 This codebase is now deprecated and replaced by https://github.com/flashbots/rbuilder
 
+So long, and thanks for all the fish.
+
+---
+
 The historic README is archived below.
 
 ---

--- a/README.md
+++ b/README.md
@@ -1,3 +1,13 @@
+# Flashbots historic geth-based block builder
+
+This repository contains the historic codebase of the Flashbots geth-based block builder.
+
+This codebase is now deprecated and replaced by https://github.com/flashbots/rbuilder
+
+The historic README is archived below.
+
+---
+
 [geth readme](README.original.md)
 
 # Flashbots Block Builder


### PR DESCRIPTION
## 📝 Summary

The geth-based builder is deprecated and replaced by https://github.com/flashbots/rbuilder

---

* [X] I have seen and agree to [`CONTRIBUTING.md`](https://github.com/flashbots/builder/blob/main/CONTRIBUTING.md)
